### PR TITLE
fix: Prevent ResizeObserver loop warnings and improve linting

### DIFF
--- a/src/apps/sidepanel/components/SidepanelMainContent.vue
+++ b/src/apps/sidepanel/components/SidepanelMainContent.vue
@@ -19,7 +19,10 @@
         />
 
         <!-- Translate Button (shown alongside language selectors in wide layout) -->
-        <div v-if="isWideLayout" class="translate-button-inline">
+        <div
+          v-if="isWideLayout"
+          class="translate-button-inline"
+        >
           <ProviderSelector
             mode="split"
             :disabled="!canTranslateFromForm"
@@ -30,7 +33,10 @@
       </div>
 
       <!-- Translate Button Row (only shown in narrow layout) -->
-      <div v-if="!isWideLayout" class="translate-button-row">
+      <div
+        v-if="!isWideLayout"
+        class="translate-button-row"
+      >
         <ProviderSelector
           mode="split"
           :disabled="!canTranslateFromForm"
@@ -156,10 +162,11 @@ const checkLayout = () => {
 // Setup resize observer
 const setupResizeObserver = () => {
   if (languageControlsRef.value && 'ResizeObserver' in window) {
-    resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
+    resizeObserver = new ResizeObserver(() => {
+      // Use requestAnimationFrame to prevent ResizeObserver loop warnings
+      requestAnimationFrame(() => {
         checkLayout()
-      }
+      })
     })
     resizeObserver.observe(languageControlsRef.value)
 

--- a/src/components/shared/LanguageSelector.vue
+++ b/src/components/shared/LanguageSelector.vue
@@ -185,10 +185,11 @@ const setupResizeObserver = () => {
   checkIsSidepanelContext()
 
   if (languageControlsRef.value && isSidepanelContext.value && 'ResizeObserver' in window) {
-    resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
+    resizeObserver = new ResizeObserver(() => {
+      // Use requestAnimationFrame to prevent ResizeObserver loop warnings
+      requestAnimationFrame(() => {
         checkLayout()
-      }
+      })
     })
     resizeObserver.observe(languageControlsRef.value)
 


### PR DESCRIPTION
## Summary
- Fixes ResizeObserver loop warnings in sidepanel components
- Improves Vue.js linting compliance by fixing formatting issues

## Changes Made
- **SidepanelMainContent.vue**: Added `requestAnimationFrame` wrapper in ResizeObserver callback to prevent loop warnings
- **LanguageSelector.vue**: Added `requestAnimationFrame` wrapper in ResizeObserver callback to prevent loop warnings
- Fixed Vue.js linting warnings:
  - Separated `class` attributes onto new lines for better readability
  - Removed unused `entry` variables from ResizeObserver callbacks

## Technical Details
The ResizeObserver loop warnings occur when the observer triggers layout changes that cause additional observations. Using `requestAnimationFrame` ensures the layout checks are scheduled for the next animation frame, preventing the infinite loop scenario.
