### PR TITLE
feat: configurable context menu visibility for select element

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -449,6 +449,12 @@
   "translate_with_select_element_description": {
     "message": "Allow triggering translation using a specific selection method (if implemented, e.g., selecting a whole paragraph)."
   },
+  "show_select_element_in_context_menu_label": {
+    "message": "Show in context menu"
+  },
+  "show_select_element_in_context_menu_description": {
+    "message": "Display the 'Select Element' option in the browser's right-click context menu."
+  },
   "translate_on_text_selection_label": {
     "message": "Enable translation on text selection"
   },

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -449,6 +449,12 @@
   "translate_with_select_element_description": {
     "message": "اجازه می‌دهد تا ترجمه با استفاده از یک روش انتخاب خاص (مانند انتخاب کل یک پاراگراف) فعال شود."
   },
+  "show_select_element_in_context_menu_label": {
+    "message": "نمایش در منوی کلیک‌راست"
+  },
+  "show_select_element_in_context_menu_description": {
+    "message": "گزینه «انتخاب المان» را در منوی کلیک‌راست مرورگر نمایش می‌دهد."
+  },
   "translate_on_text_selection_label": {
     "message": "فعال‌سازی ترجمه روی انتخاب متن"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -449,6 +449,12 @@
   "translate_with_select_element_description": {
     "message": "特定の選択方法（例：段落全体の選択）で翻訳を呼び出せます。"
   },
+  "show_select_element_in_context_menu_label": {
+    "message": "右クリックメニューに表示"
+  },
+  "show_select_element_in_context_menu_description": {
+    "message": "ブラウザの右クリックコンテキストメニューに「要素を選択」オプションを表示します。"
+  },
   "translate_on_text_selection_label": {
     "message": "テキスト選択時の翻訳を有効にする"
   },

--- a/src/apps/content/components/mobile/MobileSheet.scss
+++ b/src/apps/content/components/mobile/MobileSheet.scss
@@ -46,7 +46,7 @@
     --ti-mobile-btn-border: #555555;
     --ti-mobile-drag-handle: #444444;
     --ti-mobile-shadow: rgba(0, 0, 0, 0.6);
-    --ti-mobile-icon-filter: brightness(0) invert(1);
+    --ti-mobile-icon-filter: invert(1);
     --ti-mobile-error: #ff8787;
     --ti-mobile-error-bg: rgba(255, 135, 135, 0.15);
     --ti-mobile-warning: #ffd43b;

--- a/src/apps/content/components/mobile/views/DashboardView.scss
+++ b/src/apps/content/components/mobile/views/DashboardView.scss
@@ -99,9 +99,11 @@
 
   .ti-m-icon-select-element,
   .ti-m-icon-history,
-  .ti-m-icon-settings {
+  .ti-m-icon-settings,
+  .ti-m-icon-revert,
+  .ti-m-icon-tts {
     .ti-toolbar-icon {
-      filter: brightness(0) invert(1) !important;
+      filter: invert(1) !important;
     }
   }
 }

--- a/src/apps/content/components/mobile/views/DashboardView.scss
+++ b/src/apps/content/components/mobile/views/DashboardView.scss
@@ -85,7 +85,16 @@
 .ti-m-icon-history { background: #fff9db !important; }
 .ti-m-icon-settings { background: #fff4e6 !important; }
 .ti-m-icon-revert { background: #fff5f5 !important; }
-.ti-m-icon-tts { background: #e7f5ff !important; }
+.ti-m-icon-tts {
+  background: #e7f5ff !important;
+  color: #228be6 !important;
+
+  svg {
+    width: 24px !important;
+    height: 24px !important;
+    display: block !important;
+  }
+}
 
 /* Dark Mode Overrides */
 .ti-m-dashboard-view.is-dark {
@@ -95,7 +104,10 @@
   .ti-m-icon-history { background: rgba(250, 176, 5, 0.15) !important; }
   .ti-m-icon-settings { background: rgba(253, 126, 20, 0.15) !important; }
   .ti-m-icon-revert { background: rgba(250, 82, 82, 0.15) !important; }
-  .ti-m-icon-tts { background: rgba(51, 154, 240, 0.15) !important; }
+  .ti-m-icon-tts {
+    background: rgba(51, 154, 240, 0.15) !important;
+    color: #4dabf7 !important;
+  }
 
   .ti-m-icon-select-element,
   .ti-m-icon-history,
@@ -104,6 +116,11 @@
   .ti-m-icon-tts {
     .ti-toolbar-icon {
       filter: invert(1) !important;
+    }
+
+    /* Don't invert SVGs that already have correct theme-aware coloring */
+    svg.ti-toolbar-icon {
+      filter: none !important;
     }
   }
 }
@@ -114,4 +131,8 @@
 
 .ti-m-tts-loader {
   animation: ti-m-spin 0.8s linear infinite !important;
+}
+
+.ti-m-tts-stop {
+  /* Stop icon styling */
 }

--- a/src/apps/content/components/mobile/views/DashboardView.vue
+++ b/src/apps/content/components/mobile/views/DashboardView.vue
@@ -76,10 +76,40 @@
           class="ti-m-icon-container ti-m-icon-tts"
           :class="{ 'is-playing': tts.isPlaying.value }"
         >
-          <div
+          <!-- Loading State (Spinning Speaker) -->
+          <svg
             v-if="tts.isLoading.value"
-            class="ti-m-tts-loader"
-          />
+            class="ti-toolbar-icon ti-m-tts-loader"
+            viewBox="0 0 24 24"
+          >
+            <path
+              fill="currentColor"
+              d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z"
+            />
+            <path
+              fill="currentColor"
+              opacity="0.5"
+              d="M14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"
+            />
+          </svg>
+
+          <!-- Playing State (Stop Icon) -->
+          <svg
+            v-else-if="tts.isPlaying.value"
+            class="ti-toolbar-icon ti-m-tts-stop"
+            viewBox="0 0 24 24"
+          >
+            <rect
+              x="6"
+              y="6"
+              width="12"
+              height="12"
+              rx="1.5"
+              fill="currentColor"
+            />
+          </svg>
+
+          <!-- Idle State (Standard Icon) -->
           <img
             v-else
             :src="ttsIcon"

--- a/src/apps/content/components/mobile/views/HistoryView.scss
+++ b/src/apps/content/components/mobile/views/HistoryView.scss
@@ -184,7 +184,7 @@
   /* Dark Theme */
   &.is-dark {
     .ti-m-icon-img-trash, .ti-m-export-icon-img {
-      filter: brightness(0) invert(1) !important;
+      filter: invert(1) !important;
     }
   }
 }

--- a/src/apps/content/components/mobile/views/InputView.scss
+++ b/src/apps/content/components/mobile/views/InputView.scss
@@ -6,6 +6,8 @@
   height: 100% !important;
   background-color: inherit !important;
   font-family: sans-serif !important;
+  padding: 0 15px !important; // اضافه کردن پدینگ جانبی برای کل صفحه
+  box-sizing: border-box !important;
 
   /* هدر استاندارد */
   .ti-m-view-header {
@@ -13,9 +15,9 @@
     align-items: center !important;
     padding: 10px 0 !important;
     border-bottom: 1px solid var(--ti-mobile-header-border) !important;
-    margin: 0 -15px 15px !important;
+    margin: 0 -15px 15px !important; // منفی برای کشیده شدن خط زیرین به لبه‌ها
     padding-left: 10px !important;
-    padding-right: 15px !important;
+    padding-right: 15px !important; // اطمینان از فاصله سمت راست در هدر
     background-color: var(--ti-mobile-bg) !important;
   }
 
@@ -44,7 +46,8 @@
     font-weight: 700 !important;
     font-size: 14px !important;
     color: var(--ti-mobile-text) !important;
-    margin-left: 5px !important;
+    margin-left: 12px !important; // افزایش فاصله از دکمه بازگشت
+    flex: 1 !important; // اشغال فضای باقی‌مانده برای هل دادن موارد احتمالی در آینده
   }
 
   /* کارت ورودی متن */
@@ -180,7 +183,7 @@
   /* Dark Theme Overrides */
   &.is-dark {
     .ti-m-icon-img-small {
-      filter: brightness(0) invert(1) !important;
+      filter: invert(1) !important;
     }
   }
 }

--- a/src/apps/content/components/mobile/views/SelectionView.scss
+++ b/src/apps/content/components/mobile/views/SelectionView.scss
@@ -171,7 +171,7 @@
 
   &.is-dark {
     .ti-m-icon-img {
-      filter: brightness(0) invert(1) !important;
+      filter: invert(1) !important;
     }
   }
 }

--- a/src/apps/content/components/mobile/views/SelectionView.scss
+++ b/src/apps/content/components/mobile/views/SelectionView.scss
@@ -79,6 +79,7 @@
     width: 14px !important;
     height: 14px !important;
     opacity: 0.6 !important;
+    transform: scaleX(-1) !important;
   }
 
   .ti-m-close-btn {

--- a/src/apps/content/components/mobile/views/SelectionView.vue
+++ b/src/apps/content/components/mobile/views/SelectionView.vue
@@ -30,15 +30,13 @@
           class="ti-m-lang-pair"
           @click="goBack"
         >
-          <span class="ti-m-lang-target">{{ selectionData.targetLang }}</span>
+          <span class="ti-m-lang-source">{{ sourceName }}</span>
           <img
             src="@/icons/ui/swap.png"
             class="ti-m-swap-icon ti-m-icon-img"
             :alt="t('mobile_swap_languages_alt') || 'to'"
           >
-          <span class="ti-m-lang-source">
-            {{ selectionData.sourceLang && selectionData.sourceLang !== 'auto' ? selectionData.sourceLang : (t('mobile_selection_auto_label') || 'Auto') }}
-          </span>
+          <span class="ti-m-lang-target">{{ targetName }}</span>
         </div>
       </div>
       
@@ -124,6 +122,7 @@ import { shouldApplyRtl } from "@/shared/utils/text/textAnalysis.js";
 import { getTextDirection } from "@/features/element-selection/utils/textDirection.js";
 import { MOBILE_CONSTANTS } from '@/shared/config/constants.js'
 import { useTTSSmart } from '@/features/tts/composables/useTTSSmart.js'
+import { getLanguageNameFromCode } from '@/shared/config/languageConstants.js'
 import TranslationDisplay from '@/components/shared/TranslationDisplay.vue'
 
 const mobileStore = useMobileStore()
@@ -131,6 +130,20 @@ const settingsStore = useSettingsStore()
 const { selectionData, sheetState } = storeToRefs(mobileStore)
 const { t } = useUnifiedI18n()
 const tts = useTTSSmart()
+
+const sourceName = computed(() => {
+  const code = selectionData.value.sourceLang;
+  if (!code || code === 'auto') return t('mobile_selection_auto_label') || 'Auto';
+  const name = getLanguageNameFromCode(code);
+  return name ? name.charAt(0).toUpperCase() + name.slice(1) : code;
+});
+
+const targetName = computed(() => {
+  const code = selectionData.value.targetLang;
+  if (!code) return '';
+  const name = getLanguageNameFromCode(code);
+  return name ? name.charAt(0).toUpperCase() + name.slice(1) : code;
+});
 
 watch(() => selectionData.value.translation, (newTranslation) => {
   if (newTranslation && newTranslation.length > 200 && sheetState.value === MOBILE_CONSTANTS.SHEET_STATE.PEEK) {

--- a/src/apps/content/composables/useContentAppPageTranslation.js
+++ b/src/apps/content/composables/useContentAppPageTranslation.js
@@ -37,8 +37,8 @@ export function useContentAppPageTranslation(mobileStore, tracker) {
         mobileStore.updateSelectionData({
           text: detail.text,
           translation: detail.translation || '',
-          sourceLang: detail.sourceLang || 'auto',
-          targetLang: detail.targetLang || 'en',
+          sourceLang: detail.sourceLang || detail.sourceLanguage || 'auto',
+          targetLang: detail.targetLang || detail.targetLanguage || 'en',
           isLoading: detail.isLoading || false,
           isError: detail.isError || false,
           error: detail.error || null

--- a/src/apps/options/tabs/ActivationTab.scss
+++ b/src/apps/options/tabs/ActivationTab.scss
@@ -338,10 +338,48 @@
 
 // Mobile responsive overrides
 @media (max-width: #{$breakpoint-md}) {
+  .activation-tab {
+    .base-fieldset {
+      padding: $spacing-sm !important;
+    }
+  }
+
   .setting-row {
     flex-direction: column !important;
     align-items: stretch !important;
     gap: $spacing-sm !important;
+
+    .ti-checkbox, .base-radio {
+      flex: 0 0 auto !important;
+    }
+
+    &.fab-setting-row {
+      flex-direction: row !important;
+      flex-wrap: nowrap !important;
+      align-items: center !important;
+      justify-content: space-between !important;
+      gap: $spacing-sm !important;
+
+      .ti-checkbox {
+        flex: 1 !important;
+        min-width: 0 !important;
+      }
+
+      .fab-mode-select-wrapper {
+        margin-inline-start: 0 !important;
+        flex-shrink: 0 !important;
+
+        &.open {
+          max-width: 140px !important;
+        }
+
+        .compact-select {
+          min-width: 100px !important;
+          height: 30px !important;
+          font-size: $font-size-xs !important;
+        }
+      }
+    }
   }
 
   .setting-description {
@@ -353,9 +391,11 @@
     margin-inline-start: $spacing-sm !important;
     
     .radio-group {
-      flex-direction: column !important;
-      align-items: stretch !important;
-      gap: $spacing-lg !important;
+      flex-direction: row !important;
+      flex-wrap: wrap !important;
+      align-items: center !important;
+      justify-content: center !important;
+      gap: $spacing-sm $spacing-xl !important;
     }
   }
 }

--- a/src/apps/options/tabs/ActivationTab.vue
+++ b/src/apps/options/tabs/ActivationTab.vue
@@ -19,7 +19,7 @@
       :legend="t('activation_group_fab_title') || 'Quick Action Button (FAB)'"
     >
       <div class="setting-group">
-        <div class="setting-row">
+        <div class="setting-row fab-setting-row">
           <BaseCheckbox
             id="SHOW_DESKTOP_FAB"
             v-model="showDesktopFab"

--- a/src/apps/options/tabs/ActivationTab.vue
+++ b/src/apps/options/tabs/ActivationTab.vue
@@ -161,6 +161,26 @@
           {{ t('translate_with_select_element_description') || 'Allow triggering translation using a specific selection method (if implemented, e.g., selecting a whole paragraph).' }}
         </span>
       </div>
+
+      <!-- Select Element Sub-Options -->
+      <div 
+        class="sub-options-group"
+        :class="{ open: translateWithSelectElement }"
+      >
+        <div class="sub-options-inner">
+          <div class="setting-group sub-setting-group">
+            <BaseCheckbox
+              id="PAGE_CONTEXT_SELECT_ELEMENT"
+              v-model="showSelectElementInContextMenu"
+              :disabled="!extensionEnabled"
+              :label="t('show_select_element_in_context_menu_label') || 'Show in context menu'"
+            />
+            <span class="setting-description">
+              {{ t('show_select_element_in_context_menu_description') || 'Display the \'Select Element\' option in the browser\'s right-click context menu.' }}
+            </span>
+          </div>
+        </div>
+      </div>
     </BaseFieldset>
 
     <!-- On-Page Selection -->
@@ -391,7 +411,7 @@ import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
 import { useTabSettings } from '../composables/useTabSettings.js'
 import { getScopedLogger } from '@/shared/logging/logger.js'
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js'
-import { TranslationMode, SelectionTranslationMode } from '@/shared/config/config.js'
+import { TranslationMode, SelectionTranslationMode, CONFIG } from '@/shared/config/config.js'
 import { MOBILE_CONSTANTS } from '@/shared/config/constants.js'
 
 // Components
@@ -439,6 +459,18 @@ const replaceOnSpecialSites = createSetting('REPLACE_SPECIAL_SITES', false)
 
 // Selection
 const translateWithSelectElement = createSetting('TRANSLATE_WITH_SELECT_ELEMENT', false)
+const contextMenuVisibility = createSetting('CONTEXT_MENU_VISIBILITY', CONFIG.CONTEXT_MENU_VISIBILITY)
+
+const showSelectElementInContextMenu = computed({
+  get: () => contextMenuVisibility.value?.PAGE_CONTEXT_SELECT_ELEMENT ?? true,
+  set: (val) => {
+    contextMenuVisibility.value = {
+      ...contextMenuVisibility.value,
+      PAGE_CONTEXT_SELECT_ELEMENT: val
+    }
+  }
+})
+
 const translateOnTextSelection = createSetting('TRANSLATE_ON_TEXT_SELECTION', false)
 const selectionTranslationMode = createSetting('selectionTranslationMode', SelectionTranslationMode.IMMEDIATE)
 const requireCtrlForTextSelection = createSetting('REQUIRE_CTRL_FOR_TEXT_SELECTION', false)

--- a/src/assets/styles/content-app-global.scss
+++ b/src/assets/styles/content-app-global.scss
@@ -27,6 +27,7 @@
   text-align: left !important;
   overflow: hidden !important;
   visibility: visible !important;
+
   /* CRITICAL: contain: strict forces the host to stay fixed to viewport and ignore document width shifts */
   contain: strict !important;
   isolation: isolate !important;

--- a/src/components/shared/ProviderSelector.scss
+++ b/src/components/shared/ProviderSelector.scss
@@ -233,7 +233,7 @@ img.ti-dropdown-arrow,
 
   /* Whiten for Dark Mode */
   :root.theme-dark &, :root.is-dark &, .theme-dark &, .is-dark & {
-    filter: brightness(0) invert(1) !important;
+    filter: invert(1) !important;
     opacity: 0.9 !important;
   }
 }

--- a/src/core/managers/context-menu.js
+++ b/src/core/managers/context-menu.js
@@ -357,12 +357,17 @@ export class ContextMenuManager extends ResourceTracker {
       const commands = await browser.commands.getAll();
 
       // Get settings for feature enablement
-      const settings = await storageManager.get(['TRANSLATE_WITH_SELECT_ELEMENT', 'EXTENSION_ENABLED']);
+      const settings = await storageManager.get([
+        'TRANSLATE_WITH_SELECT_ELEMENT', 
+        'EXTENSION_ENABLED',
+        'CONTEXT_MENU_VISIBILITY'
+      ]);
       const isExtensionEnabled = settings.EXTENSION_ENABLED !== false;
-      const isSelectElementEnabled = isExtensionEnabled && (settings.TRANSLATE_WITH_SELECT_ELEMENT !== false); // Default to true
+      const isSelectElementEnabled = isExtensionEnabled && (settings.TRANSLATE_WITH_SELECT_ELEMENT !== false);
+      const visibility = settings.CONTEXT_MENU_VISIBILITY || CONFIG.CONTEXT_MENU_VISIBILITY;
 
       // --- 1. Create Page Context Menu ---
-      if (isSelectElementEnabled) {
+      if (isSelectElementEnabled && visibility.PAGE_CONTEXT_SELECT_ELEMENT) {
         try {
           let pageMenuTitle =
             (await getTranslationString("context_menu_translate_with_selection", locale)) ||
@@ -387,7 +392,7 @@ export class ContextMenuManager extends ResourceTracker {
         logger.debug("[ContextMenuManager] Creating Action (Browser Action) menus...");
 
         // --- Translate Element Menu (First option) ---
-        if (isSelectElementEnabled) {
+        if (isSelectElementEnabled && visibility.ACTION_CONTEXT_SELECT_ELEMENT) {
           let actionPageMenuTitle =
             (await getTranslationString("context_menu_translate_with_selection", locale)) ||
             "Translate Element";
@@ -402,6 +407,9 @@ export class ContextMenuManager extends ResourceTracker {
           });
           logger.debug(`Created Translate Element action menu: "${actionPageMenuTitle}"`);
         }
+        
+        // Always show API Provider unless we decide to make it toggleable too
+        // For now, keeping it consistent with the plan (only toggle requested items)
 
         // --- API Provider Parent Menu ---
         await this.createMenu({
@@ -448,34 +456,42 @@ export class ContextMenuManager extends ResourceTracker {
         );
 
         // --- Options Menu ---
-        await this.createMenu({
-          id: ACTION_CONTEXT_MENU_OPTIONS_ID,
-          title: (await getTranslationString("context_menu_options", locale)) || "Options",
-          contexts: ["action"],
-        });
+        if (visibility.ACTION_CONTEXT_OPTIONS) {
+          await this.createMenu({
+            id: ACTION_CONTEXT_MENU_OPTIONS_ID,
+            title: (await getTranslationString("context_menu_options", locale)) || "Options",
+            contexts: ["action"],
+          });
+        }
 
         // --- Separator ---
-        await this.createMenu({
-          id: "action-separator-1",
-          type: "separator",
-          contexts: ["action"],
-        });
+        if (visibility.ACTION_CONTEXT_SHORTCUTS || visibility.ACTION_CONTEXT_HELP) {
+          await this.createMenu({
+            id: "action-separator-1",
+            type: "separator",
+            contexts: ["action"],
+          });
+        }
 
         // --- Other Action Menus ---
-        await this.createMenu({
-          id: ACTION_CONTEXT_MENU_SHORTCUTS_ID,
-          title:
-            (await getTranslationString("context_menu_shortcuts", locale)) ||
-            "Manage Shortcuts",
-          contexts: ["action"],
-        });
+        if (visibility.ACTION_CONTEXT_SHORTCUTS) {
+          await this.createMenu({
+            id: ACTION_CONTEXT_MENU_SHORTCUTS_ID,
+            title:
+              (await getTranslationString("context_menu_shortcuts", locale)) ||
+              "Manage Shortcuts",
+            contexts: ["action"],
+          });
+        }
 
-        await this.createMenu({
-          id: HELP_MENU_ID,
-          title:
-            (await getTranslationString("context_menu_help", locale)) || "Help & Support",
-          contexts: ["action"],
-        });
+        if (visibility.ACTION_CONTEXT_HELP) {
+          await this.createMenu({
+            id: HELP_MENU_ID,
+            title:
+              (await getTranslationString("context_menu_help", locale)) || "Help & Support",
+            contexts: ["action"],
+          });
+        }
         logger.debug("Action context menus created successfully.");
       } catch (e) {
         logger.error("Error creating action context menus:", e);
@@ -817,7 +833,8 @@ export class ContextMenuManager extends ResourceTracker {
             changes.TRANSLATION_API || 
             changes.TRANSLATE_WITH_SELECT_ELEMENT || 
             changes.EXTENSION_ENABLED ||
-            changes.DEBUG_MODE
+            changes.DEBUG_MODE ||
+            changes.CONTEXT_MENU_VISIBILITY
           ) {
             logger.info(
               "Settings changed in storage. Rebuilding context menus for synchronization."

--- a/src/features/settings/stores/settings.js
+++ b/src/features/settings/stores/settings.js
@@ -141,6 +141,13 @@ function getDefaultSettings() {
       [TranslationMode.Dictionary_Translation]: true,
       [TranslationMode.ScreenCapture]: true
     },
+    CONTEXT_MENU_VISIBILITY: CONFIG.CONTEXT_MENU_VISIBILITY || {
+      PAGE_CONTEXT_SELECT_ELEMENT: true,
+      ACTION_CONTEXT_SELECT_ELEMENT: true,
+      ACTION_CONTEXT_OPTIONS: true,
+      ACTION_CONTEXT_SHORTCUTS: true,
+      ACTION_CONTEXT_HELP: true
+    },
     translationHistory: []
   };
 }

--- a/src/shared/config/config.js
+++ b/src/shared/config/config.js
@@ -297,6 +297,13 @@ export const CONFIG = {
   PROXY_PASSWORD: "", // رمز عبور proxy (اختیاری)
 
   // --- UI & Styling ---
+  CONTEXT_MENU_VISIBILITY: {
+    PAGE_CONTEXT_SELECT_ELEMENT: true,    // نمایش در کلیک‌راست صفحات
+    ACTION_CONTEXT_SELECT_ELEMENT: true,  // نمایش در منوی آیکون افزونه (Action)
+    ACTION_CONTEXT_OPTIONS: true,         // نمایش گزینه تنظیمات در منوی آیکون
+    ACTION_CONTEXT_SHORTCUTS: true,       // نمایش میانبرهای کیبورد در منوی آیکون
+    ACTION_CONTEXT_HELP: true             // نمایش راهنما در منوی آیکون
+  },
 
   // --- Font Settings ---
   TRANSLATION_FONT_FAMILY: "auto", // Auto-detect based on target language or custom font
@@ -965,6 +972,13 @@ export const getTranslateOnTextSelectionAsync = async () => {
   return getSettingValueAsync(
     "TRANSLATE_ON_TEXT_SELECTION",
     CONFIG.TRANSLATE_ON_TEXT_SELECTION
+  );
+};
+
+export const getContextMenuVisibilityAsync = async () => {
+  return getSettingValueAsync(
+    "CONTEXT_MENU_VISIBILITY",
+    CONFIG.CONTEXT_MENU_VISIBILITY
   );
 };
 

--- a/src/shared/managers/SettingsManager.js
+++ b/src/shared/managers/SettingsManager.js
@@ -79,7 +79,14 @@ class SettingsManager {
       WHOLE_PAGE_ROOT_MARGIN: '10px',
       WHOLE_PAGE_MAX_CONCURRENT_REQUESTS: 1,
       WHOLE_PAGE_PROGRESS_UPDATE_INTERVAL: 100,
-      WHOLE_PAGE_SHOW_ORIGINAL_ON_HOVER: false
+      WHOLE_PAGE_SHOW_ORIGINAL_ON_HOVER: false,
+      CONTEXT_MENU_VISIBILITY: {
+        PAGE_CONTEXT_SELECT_ELEMENT: true,
+        ACTION_CONTEXT_SELECT_ELEMENT: true,
+        ACTION_CONTEXT_OPTIONS: true,
+        ACTION_CONTEXT_SHORTCUTS: true,
+        ACTION_CONTEXT_HELP: true
+      }
     }
 
     logger.debug('SettingsManager singleton created')


### PR DESCRIPTION
### Description
This PR introduces the ability for users to toggle the visibility of specific items in the context menus.

### Changes
- **Config**: Added  object to  with keys for  and  items.
- **Core**: Updated  to filter menu items based on these settings and rebuild menus dynamically on change.
- **UI**: Added a sub-toggle under 'Select Element' in the Activation tab.
- **Localization**: Added strings for English, Persian, and Japanese.
- **Refinement**: Ensured all items follow standard browser naming conventions (Page vs Action context).