### PR TITLE
Fix: Text selection window not appearing with Ctrl requirement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ##### Fixed
 
+- Fixed an issue where the translation window would not appear when the `Require Ctrl` setting was enabled
 - Fixed an issue where mode-specific providers (Mobile, Context Menu, and Text Field) were not properly applied
 - Fixed incorrect Circuit Breaker trigger conditions
 - Fixed an issue where page translation would stop working after an error

--- a/src/features/text-field-interaction/handlers/TextFieldDoubleClickHandler.js
+++ b/src/features/text-field-interaction/handlers/TextFieldDoubleClickHandler.js
@@ -850,6 +850,11 @@ export class TextFieldDoubleClickHandler extends ResourceTracker {
       text: selectedText,
       position: position,
       mode: selectionTranslationMode,
+      options: {
+        ctrlPressed: true, // Always treat as pressed for double-click in text fields
+        shiftPressed: false,
+        isTextField: true
+      },
       context: {
         isTextField: true,
         isIframe: window !== window.top

--- a/src/features/text-field-interaction/handlers/TextFieldDoubleClickHandler.test.js
+++ b/src/features/text-field-interaction/handlers/TextFieldDoubleClickHandler.test.js
@@ -169,7 +169,8 @@ describe('TextFieldDoubleClickHandler', () => {
       
       expect(pageEventBus.emit).toHaveBeenCalledWith('global-selection-change', expect.objectContaining({
         text: 'hello',
-        position: expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) })
+        position: expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }),
+        options: expect.objectContaining({ ctrlPressed: true, isTextField: true })
       }));
     });
 

--- a/src/features/text-selection/core/SelectionManager.js
+++ b/src/features/text-selection/core/SelectionManager.js
@@ -114,6 +114,7 @@ export class SelectionManager extends ResourceTracker {
       text: selectedText,
       position: position,
       mode: selectionTranslationMode,
+      options: options, // Pass keyboard state (ctrlPressed, shiftPressed)
       context: {
         frameId: this.frameId,
         isIframe: window !== window.top

--- a/src/features/windows/managers/WindowsManager.test.js
+++ b/src/features/windows/managers/WindowsManager.test.js
@@ -230,6 +230,32 @@ describe('WindowsManager', () => {
       
       expect(mockWindowsManagerEvents.dismissIcon).toHaveBeenCalled();
     });
+
+    it('should respect Ctrl requirement in IMMEDIATE mode', async () => {
+      vi.mocked(settingsManager.get).mockImplementation((key, def) => {
+        if (key === 'selectionTranslationMode') return 'immediate';
+        if (key === 'REQUIRE_CTRL_FOR_TEXT_SELECTION') return true;
+        return def;
+      });
+      
+      // 1. Test when Ctrl is NOT pressed (options provided but ctrlPressed false)
+      await mockPageEventBus.emit(SELECTION_EVENTS.GLOBAL_SELECTION_CHANGE, { 
+        text: 'test', 
+        position: {x:1, y:1},
+        options: { ctrlPressed: false }
+      });
+      await vi.runAllTimersAsync();
+      expect(mockWindowsManagerEvents.showWindow).not.toHaveBeenCalled();
+
+      // 2. Test when Ctrl IS pressed
+      await mockPageEventBus.emit(SELECTION_EVENTS.GLOBAL_SELECTION_CHANGE, { 
+        text: 'test', 
+        position: {x:1, y:1},
+        options: { ctrlPressed: true }
+      });
+      await vi.runAllTimersAsync();
+      expect(mockWindowsManagerEvents.showWindow).toHaveBeenCalled();
+    });
   });
 
   describe('Translation Flow', () => {
@@ -246,6 +272,11 @@ describe('WindowsManager', () => {
       const { deviceDetector } = await import('@/utils/browser/compatibility.js');
       vi.mocked(deviceDetector.shouldEnableMobileUI).mockReturnValue(true);
       
+      vi.mocked(settingsManager.get).mockImplementation((key, def) => {
+        if (key === 'selectionTranslationMode') return 'immediate';
+        return def;
+      });
+
       await windowsManager.show('mob', {x:0, y:0});
       expect(mockWindowsManagerEvents.showMobileSheet).toHaveBeenCalled();
     });


### PR DESCRIPTION
This PR fixes a bug where the translation window failed to appear when the `Require Ctrl` setting was enabled. The issue was caused by the keyboard state not being passed through the global selection change event.

Key changes:
- Updated SelectionManager to include keyboard state (ctrlPressed) in selection events.
- Updated TextFieldDoubleClickHandler to ensure text field interactions bypass the Ctrl requirement.
- Added regression tests for the Ctrl requirement logic.