### PR TITLE
feat(tts): implement owner-aware cleanup system

### DIFF
--- a/docs/technical/DESKTOP_FAB_SYSTEM.md
+++ b/docs/technical/DESKTOP_FAB_SYSTEM.md
@@ -64,6 +64,7 @@ This composable decouples FAB logic from the visual component:
 
 ### 3. Integrated Smart TTS Controller
 The FAB includes an advanced TTS badge that leverages the global `useTTSSmart` system.
+- **Owner-Aware Cleanup**: The FAB's audio is protected by the "Owner-Aware Cleanup" logic. Closing the extension popup or sidepanel will NOT interrupt FAB playback unless they were the initiators.
 - **Actual Language Metadata**: Integrates with the `TranslationEngine` to identify the *actual* language used for translation. After a successful translation, it prioritizes the returned `actualSourceLanguage` for accurate TTS accents and labels, especially during Bilingual swaps.
 - **Auto Language Detection**: For initial (pre-translation) state, it uses `LanguageDetectionService` to identify the language of the selected text in real-time.
 - **Visual State Management**:

--- a/docs/technical/MOBILE_SUPPORT.md
+++ b/docs/technical/MOBILE_SUPPORT.md
@@ -54,6 +54,7 @@ The central state manager for the touch-optimized UI. It manages:
 - **Visibility**: `isOpen`, `isFullscreen`.
 - **Navigation**: `activeView` (Dashboard, Selection, Input, etc.).
 - **Visual State**: `sheetState` (Closed, Peek, Full).
+- **Owner-Aware TTS Cleanup**: Closing the bottom sheet triggers a localized cleanup that only stops audio initiated by the sheet itself, preventing interference with other contexts.
 - **Selection Data**: Synchronized with global selection events. It specifically tracks `actualSourceLanguage` and `actualTargetLanguage` from translation results to ensure the UI labels (e.g., in the header) reflect the real language pair used by the engine, regardless of the initial "Auto" setting.
 
 ### 2. Gesture Engine (`useMobileGestures.js`)

--- a/docs/technical/TTS_SYSTEM.md
+++ b/docs/technical/TTS_SYSTEM.md
@@ -92,6 +92,12 @@ Handles the dynamic aspects of Microsoft Edge voices:
 - **Caching**: Implements a 24-hour cache in `storage.local` to avoid redundant network requests.
 - **Dialect Prioritization**: Implements a "Preferred Region" logic (e.g., prioritizing `en-US` over `en-AU` for English) to ensure natural sounding defaults.
 
+### 9. Owner-Aware Cleanup Logic
+To prevent cross-context interruptions (e.g., closing the Popup stopping a Desktop FAB playback), the system implements an **Ownership Verification** mechanism:
+- **`isCurrentOwner(sender)`**: The `TTSStateManager` identifies the initiator of the current audio using Tab IDs, Frame IDs, or internal URLs.
+- **`stopOnlyIfOwner` Flag**: Automatic cleanup triggers (like window closure or visibility changes) pass this flag. The background script only executes the stop command if the sender is the verified owner.
+- **Manual Overrides**: User-initiated actions (clicking a Stop button or starting new text) bypass this check to ensure the **Exclusive Playback** rule is maintained.
+
 ---
 
 ## Smart Language Detection & Voice Selection

--- a/src/apps/content/components/desktop/DesktopFabMenu.vue
+++ b/src/apps/content/components/desktop/DesktopFabMenu.vue
@@ -240,7 +240,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n';
 import { MessageActions } from '@/shared/messaging/core/MessageActions.js';
 import { getScopedLogger } from '@/shared/logging/logger.js';
@@ -876,5 +876,10 @@ onMounted(async () => {
   };
 
   tracker.addEventListener(window, 'click', handleClickOutside);
+});
+
+onUnmounted(() => {
+  logger.debug('[DesktopFabMenu] Unmounting - performing owner-aware TTS cleanup');
+  tts.stop({ stopOnlyIfOwner: true }).catch(() => {});
 });
 </script>

--- a/src/apps/content/components/mobile/MobileSheet.vue
+++ b/src/apps/content/components/mobile/MobileSheet.vue
@@ -51,6 +51,8 @@ import { MOBILE_CONSTANTS } from '@/shared/constants/mobile.js'
 import { useResourceTracker } from '@/composables/core/useResourceTracker.js'
 import { getScopedLogger } from '@/shared/logging/logger.js'
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js'
+import { sendMessage } from '@/shared/messaging/core/UnifiedMessaging.js'
+import { MessageActions } from '@/shared/messaging/core/MessageActions.js'
 
 import DashboardView from './views/DashboardView.vue'
 import SelectionView from './views/SelectionView.vue'
@@ -146,6 +148,17 @@ watch(isOpen, (newValue) => {
     document.body.style.overflow = ''
     document.body.style.touchAction = ''
     document.documentElement.style.overflow = ''
+
+    // Owner-aware TTS cleanup when sheet closes
+    if (newValue === false) {
+      sendMessage({
+        action: MessageActions.TTS_STOP,
+        data: { 
+          source: 'mobile-sheet-close',
+          stopOnlyIfOwner: true 
+        }
+      }).catch(err => logger.debug('Failed to stop TTS on mobile sheet close:', err));
+    }
   }
 }, { immediate: true })
 

--- a/src/apps/popup/PopupApp.vue
+++ b/src/apps/popup/PopupApp.vue
@@ -252,7 +252,13 @@ onMounted(() => {
    */
   ttsGlobal.register(async () => {
     try {
-      await sendMessage({ action: MessageActions.TTS_STOP, data: { source: 'popup-cleanup' } })
+      await sendMessage({ 
+        action: MessageActions.TTS_STOP, 
+        data: { 
+          source: 'popup-cleanup',
+          stopOnlyIfOwner: true
+        } 
+      })
     } catch (error) {
       logger.error('[PopupApp] Failed to stop TTS during cleanup:', error)
     }

--- a/src/apps/sidepanel/SidepanelApp.vue
+++ b/src/apps/sidepanel/SidepanelApp.vue
@@ -168,7 +168,10 @@ const initialize = async () => {
         // Send direct TTS stop message to background to stop any playing TTS
         browser.runtime.sendMessage({
           action: MessageActions.TTS_STOP,
-          data: {}
+          data: { 
+            source: 'sidepanel-hidden',
+            stopOnlyIfOwner: true
+          }
         }).catch(error => {
           logger.debug('[SidepanelApp] Failed to send TTS stop message in visibility change:', error)
         })
@@ -185,7 +188,10 @@ const initialize = async () => {
       // Send direct TTS stop message to background to stop any playing TTS
       browser.runtime.sendMessage({
         action: MessageActions.TTS_STOP,
-        data: {}
+        data: {
+          source: 'sidepanel-pagehide',
+          stopOnlyIfOwner: true
+        }
       }).catch(error => {
         logger.debug('[SidepanelApp] Failed to send TTS stop message in pagehide:', error)
       })
@@ -230,7 +236,10 @@ onBeforeUnmount(() => {
     // Send direct TTS stop message to background to stop any playing TTS
     browser.runtime.sendMessage({
       action: MessageActions.TTS_STOP,
-      data: {}
+      data: {
+        source: 'sidepanel-unmount',
+        stopOnlyIfOwner: true
+      }
     }).catch(error => {
       logger.debug('[SidepanelApp] Failed to send TTS stop message:', error)
     })

--- a/src/core/background/index.js
+++ b/src/core/background/index.js
@@ -52,8 +52,11 @@ async function performUiCleanup(context, sender) {
         logger.debug(`[Background] Stopping TTS for ${context} closure`);
         await ttsHandler({ 
           action: 'TTS_STOP', 
-          data: { source: `${context}-port-disconnect` } 
-        });
+          data: { 
+            source: `${context}-port-disconnect`,
+            stopOnlyIfOwner: true
+          } 
+        }, sender);
       }
 
       // 2. Cancel all active translations from UI

--- a/src/features/translation/composables/useTranslationModes.js
+++ b/src/features/translation/composables/useTranslationModes.js
@@ -430,6 +430,7 @@ export function useSidepanelActions() {
       logger.debug('Stopping TTS');
       await sendMessage({
         action: MessageActions.TTS_STOP,
+        data: { stopOnlyIfOwner: true },
         context: MessageContexts.SIDEPANEL,
         timestamp: Date.now()
       });

--- a/src/features/tts/composables/useTTSSmart.js
+++ b/src/features/tts/composables/useTTSSmart.js
@@ -150,14 +150,18 @@ export function useTTSSmart() {
 
   /**
    * Stops the current instance's TTS request
+   * @param {Object} options - Stop options
    */
-  const stop = async () => {
+  const stop = async (options = {}) => {
     if (ttsState.value === 'idle') return true;
 
     try {
       const message = {
         action: MessageActions.TTS_STOP,
-        data: { ttsId: currentTTSId.value },
+        data: { 
+          ttsId: currentTTSId.value,
+          ...options
+        },
         context: 'tts-smart'
       };
       
@@ -173,12 +177,13 @@ export function useTTSSmart() {
 
   /**
    * Stops ALL TTS requests globally
+   * @param {Object} options - Stop options
    */
-  const stopAll = async () => {
+  const stopAll = async (options = {}) => {
     try {
       const message = {
         action: MessageActions.TTS_STOP,
-        data: {},
+        data: { ...options },
         context: 'tts-smart'
       };
       

--- a/src/features/tts/handlers/handleEdgeTTS.js
+++ b/src/features/tts/handlers/handleEdgeTTS.js
@@ -90,13 +90,20 @@ export const handleEdgeTTSSpeak = async (message, sender, overrideLanguage = nul
 /**
  * Handle TTS Stop request for Edge TTS
  */
-export const handleEdgeTTSStopAll = async (message) => {
+export const handleEdgeTTSStopAll = async (message, sender) => {
   try {
-    const { ttsId } = message.data || {};
+    const { ttsId, stopOnlyIfOwner } = message.data || {};
     const isSpecificStop = ttsId && ttsId !== 'all';
     
+    // 1. Specific ID check
     if (isSpecificStop && ttsStateManager.currentTTSId !== ttsId) {
       return { success: true, skipped: true };
+    }
+
+    // 2. Ownership check (for automatic cleanups)
+    if (stopOnlyIfOwner && !ttsStateManager.isCurrentOwner(sender)) {
+      logger.debug('[EdgeTTS] Ignoring stop request: sender is not the owner');
+      return { success: true, skipped: true, reason: 'not_owner' };
     }
     
     // Stop any active queue

--- a/src/features/tts/handlers/handleGoogleTTS.js
+++ b/src/features/tts/handlers/handleGoogleTTS.js
@@ -136,13 +136,20 @@ export const handleGoogleTTSSpeak = async (message, sender, overrideLanguage = n
 /**
  * Handle TTS Stop request
  */
-export const handleGoogleTTSStopAll = async (message) => {
+export const handleGoogleTTSStopAll = async (message, sender) => {
   try {
-    const { ttsId } = message.data || {};
+    const { ttsId, stopOnlyIfOwner } = message.data || {};
     const isSpecificStop = ttsId && ttsId !== 'all';
     
+    // 1. Specific ID check
     if (isSpecificStop && ttsStateManager.currentTTSId !== ttsId) {
       return { success: true, skipped: true };
+    }
+
+    // 2. Ownership check (for automatic cleanups)
+    if (stopOnlyIfOwner && !ttsStateManager.isCurrentOwner(sender)) {
+      logger.debug('[GoogleTTS] Ignoring stop request: sender is not the owner');
+      return { success: true, skipped: true, reason: 'not_owner' };
     }
     
     // Stop any active queue

--- a/src/features/tts/services/TTSStateManager.js
+++ b/src/features/tts/services/TTSStateManager.js
@@ -98,6 +98,27 @@ class TTSStateManager {
   }
 
   /**
+   * Check if a sender is the current owner of the active TTS session.
+   * This is used for owner-aware cleanup.
+   * 
+   * @param {Object} sender - The message sender to check
+   * @returns {boolean} True if the sender is the current owner
+   */
+  isCurrentOwner(sender) {
+    if (!this.currentTTSSender || !sender) return false;
+
+    // 1. Internal Context Match (Popup/Sidepanel/Options)
+    // Internal contexts often don't have a tab ID, so we check the URL
+    if (!sender.tab?.id && !this.currentTTSSender.tab?.id) {
+      return sender.url === this.currentTTSSender.url;
+    }
+
+    // 2. Tab/Frame Match (Content Scripts / FAB)
+    return sender.tab?.id === this.currentTTSSender.tab?.id && 
+           sender.frameId === this.currentTTSSender.frameId;
+  }
+
+  /**
    * Complete reset of all state
    */
   fullReset() {

--- a/src/features/windows/components/TranslationWindow.vue
+++ b/src/features/windows/components/TranslationWindow.vue
@@ -334,7 +334,7 @@ onMounted(async () => {
   // Track all resources for automatic cleanup
   tracker.trackResource('positioning', () => cleanupPositioning());
   tracker.trackResource('tts-stop', () => {
-    tts.stopAll().catch(() => {});
+    tts.stopAll({ stopOnlyIfOwner: true }).catch(() => {});
   });
 });
 


### PR DESCRIPTION
### Overview
This PR implements an **Owner-Aware TTS Cleanup** system to prevent cross-context audio interruptions. 

### Key Changes
- **Background Logic**: Added ownership verification in `TTSStateManager` and updated stop handlers to respect the `stopOnlyIfOwner` flag.
- **UI Integration**: Updated `Popup`, `Sidepanel`, `Mobile Sheet`, and `WindowsManager` to use the new cleanup logic during closure/unmount.
- **Documentation**: Updated technical guides for TTS, FAB, and Mobile Support to reflect this architectural change.

### Impact
Closing a UI element (like the popup) will no longer stop TTS audio initiated by another context (like the Desktop FAB), while still maintaining the `Exclusive Playback` rule for user-initiated actions.