### PR TITLE
fix(select-element): improve event interception and resolve Twitter click-through issue

### DIFF
--- a/src/assets/styles/content-main-dom.css
+++ b/src/assets/styles/content-main-dom.css
@@ -34,7 +34,7 @@ html[data-translate-it-select-mode="true"] div[role="link"]:not([data-sonner-toa
 html[data-translate-it-select-mode="true"] input[type="submit"]:not([data-sonner-toast], [data-sonner-toaster], [data-translate-ui]),
 html[data-translate-it-select-mode="true"] input[type="button"]:not([data-sonner-toast], [data-sonner-toaster], [data-translate-ui]),
 html[data-translate-it-select-mode="true"] [href]:not([data-sonner-toast], [data-sonner-toaster], [data-translate-ui]) {
-  pointer-events: none;
+  cursor: crosshair;
   color: inherit;
   text-decoration: none;
 }

--- a/src/assets/styles/content-main-dom.scss
+++ b/src/assets/styles/content-main-dom.scss
@@ -34,7 +34,7 @@ html[data-translate-it-select-mode="true"] {
   input[type="submit"]:not([data-sonner-toast], [data-sonner-toaster], [data-translate-ui]),
   input[type="button"]:not([data-sonner-toast], [data-sonner-toaster], [data-translate-ui]),
   [href]:not([data-sonner-toast], [data-sonner-toaster], [data-translate-ui]) {
-    pointer-events: none;
+    cursor: crosshair;
     color: inherit;
     text-decoration: none;
   }

--- a/src/features/element-selection/SelectElementManager.js
+++ b/src/features/element-selection/SelectElementManager.js
@@ -313,9 +313,12 @@ class SelectElementManager extends ResourceTracker {
       window.addEventListener('touchmove', this.handleTouchMove, { capture: true, passive: false });
       window.addEventListener('touchend', this.handleTouchEnd, { capture: true, passive: false });
 
-      const interactionEvents = ['click', 'dblclick', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'contextmenu', 'dragstart'];
+      // Robust interaction blocking: Include auxclick for middle-click and ensure capture phase
+      const interactionEvents = ['click', 'dblclick', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'contextmenu', 'dragstart', 'auxclick'];
       interactionEvents.forEach(eventType => {
         window.addEventListener(eventType, this.handleInteraction, { capture: true, passive: false });
+        // Secondary safety: some sites use document-level capture listeners
+        document.addEventListener(eventType, this.handleInteraction, { capture: true, passive: false });
       });
 
       window.addEventListener('keydown', this.handleKeyDown, true);
@@ -338,9 +341,10 @@ class SelectElementManager extends ResourceTracker {
     window.removeEventListener('touchmove', this.handleTouchMove, { capture: true, passive: false });
     window.removeEventListener('touchend', this.handleTouchEnd, { capture: true, passive: false });
     
-    const interactionEvents = ['click', 'dblclick', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'contextmenu', 'dragstart'];
+    const interactionEvents = ['click', 'dblclick', 'mousedown', 'mouseup', 'pointerdown', 'pointerup', 'contextmenu', 'dragstart', 'auxclick'];
     interactionEvents.forEach(eventType => {
       window.removeEventListener(eventType, this.handleInteraction, { capture: true, passive: false });
+      document.removeEventListener(eventType, this.handleInteraction, { capture: true, passive: false });
     });
 
     window.removeEventListener('keydown', this.handleKeyDown, true);
@@ -350,7 +354,7 @@ class SelectElementManager extends ResourceTracker {
     }
   }
 
-  isCooldownActive() { return Date.now() - (this.activationTime || 0) < 500; }
+  isCooldownActive() { return Date.now() - (this.activationTime || 0) < 100; }
 
   handleMouseOver(event) {
     if (!this.isActive || this.isProcessingClick || this.isCooldownActive()) return;

--- a/src/features/element-selection/SelectElementManager.test.js
+++ b/src/features/element-selection/SelectElementManager.test.js
@@ -276,6 +276,17 @@ describe('SelectElementManager', () => {
       manager.handleTouchMove(moveEvent);
       expect(manager.elementSelector.handleMouseOver).toHaveBeenCalledWith(mockElement);
     });
+
+    it('should block auxclick (middle-click) interaction', () => {
+      const event = new MouseEvent('auxclick', { bubbles: true, cancelable: true });
+      vi.spyOn(event, 'preventDefault');
+      vi.spyOn(event, 'stopImmediatePropagation');
+      
+      manager.handleInteraction(event);
+      
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopImmediatePropagation).toHaveBeenCalled();
+    });
   });
 
   describe('cross-frame and notifications', () => {


### PR DESCRIPTION
### Summary
This PR fixes the issue where the Select Element mode fails to intercept clicks on some parts of Twitter (X), causing unwanted navigation instead of translation.

### Key Changes
- CSS Refinement: Removed pointer-events: none from content-main-dom styles. This allows the `ElementSelector` to correctly receive hover events and highlight interactive elements like links and buttons.
- Robust Event Interception: 
    - Added `auxclick` to the list of intercepted events to block middle-click navigation.
    - Registered interaction listeners at both window and document levels in the capture phase to ensure we beat site-specific handlers (like Twitter's).
- UX Optimization: Reduced activation cooldown from 500ms to 100ms for better responsiveness.
- Testing: Added a unit test in `SelectElementManager.test.js` to verify auxclick blocking.

### Verification Results
- All unit tests passed.
- Verified that auxclick is correctly intercepted.
- Verified that interaction blocking is now more robust across different DOM levels.