### PR TITLE
fix: resolve mouse hover flickering and professionalize container styling

### DIFF
--- a/src/features/mouse-hover/HoverTextDetector.js
+++ b/src/features/mouse-hover/HoverTextDetector.js
@@ -54,6 +54,12 @@ export class HoverTextDetector {
         break;
     }
 
+    // Ensure we always return the most stable block container for the element property,
+    // while keeping the rect specific to the detection scope (word/sentence/container).
+    if (result && result.element) {
+      result.element = this._getClosestBlockContainer(result.element);
+    }
+
     // Hit-test: Ensure the mouse is actually over the bounding box of the detected text
     // with a small tolerance for better UX.
     // Also verify using elementFromPoint to handle potential CSS transforms correctly.
@@ -229,6 +235,17 @@ export class HoverTextDetector {
       element: container,
       rect: container.getBoundingClientRect()
     };
+  }
+
+  /**
+   * Helper to find the nearest meaningful block container.
+   * Helps in providing stable event targets.
+   * @private
+   */
+  static _getClosestBlockContainer(element) {
+    if (!element) return null;
+    const blockSelectors = 'p, div, li, h1, h2, h3, h4, h5, h6, article, section, blockquote, td, th';
+    return element.closest(blockSelectors) || element;
   }
 
   /**

--- a/src/features/mouse-hover/HoverTranslationManager.js
+++ b/src/features/mouse-hover/HoverTranslationManager.js
@@ -17,6 +17,7 @@ const logger = getScopedLogger(LOG_COMPONENTS.ON_HOVER, 'HoverTranslationManager
 // Constants for magic numbers
 const MOUSE_MOVEMENT_THRESHOLD = 2; // pixels
 const MODIFIER_TRIGGER_DELAY = 50; // ms
+const COORDINATE_TOLERANCE = 10; // pixels - buffer to handle line-height gaps and jitter
 
 /**
  * HoverTranslationManager - Manages "Mouse on Hover" translation logic
@@ -115,11 +116,26 @@ export class HoverTranslationManager extends ResourceTracker {
     
     this.lastPosition = { x: event.clientX, y: event.clientY };
 
+    // 1. PROACTIVE CHECK: If we have an active rectangle, check if we've left it.
+    // This MUST run before any modifier or editable checks to ensure the tooltip
+    // closes correctly when moving away, even if the trigger key is released.
+    if (this.currentRect && settingsManager.get('MOUSE_HOVER_AUTO_CLOSE', 'mouseleave') === 'mouseleave') {
+      const tolerance = COORDINATE_TOLERANCE;
+      const isStillInside = (
+        event.clientX >= this.currentRect.left - tolerance &&
+        event.clientX <= this.currentRect.right + tolerance &&
+        event.clientY >= this.currentRect.top - tolerance &&
+        event.clientY <= this.currentRect.bottom + tolerance
+      );
+
+      if (!isStillInside) {
+        this._handleMouseOut();
+      }
+    }
+
     // Skip if mouse is over extension UI elements (like the tooltip itself)
     if (ElementDetectionService.getInstance().isUIElement(event.target)) {
       this._cancelPendingHover();
-      // DO NOT call _handleMouseOut here, as we want to keep the tooltip open
-      // while the user is interacting with it (e.g., scrolling).
       return;
     }
 
@@ -135,27 +151,13 @@ export class HoverTranslationManager extends ResourceTracker {
     // Check modifier key if required
     if (trigger !== 'hover' && !this._isModifierPressed(event, trigger)) {
       this._cancelPendingHover();
-      this._handleMouseOut();
-      return;
-    }
-
-    // Proactive check: If we're already showing a tooltip or have a detected area, 
-    // check if we've left the bounds to improve responsiveness.
-    if (this.currentRect && settingsManager.get('MOUSE_HOVER_AUTO_CLOSE', 'mouseleave') === 'mouseleave') {
-      const isStillInside = (
-        event.clientX >= this.currentRect.left &&
-        event.clientX <= this.currentRect.right &&
-        event.clientY >= this.currentRect.top &&
-        event.clientY <= this.currentRect.bottom
-      );
-
-      if (isStillInside) {
-        // We are still within the same word/sentence area, NO NEED to recalculate anything
-        return;
-      }
       
-      // We left the previously detected rectangle
-      this._handleMouseOut();
+      // If we don't have a tooltip, we can stop here. 
+      // If we DO have one, we let it stay until the coordinate check above or mouseleave closes it.
+      if (!this.currentRect) {
+        this._handleMouseOut();
+      }
+      return;
     }
 
     this._cancelPendingHover();
@@ -238,26 +240,42 @@ export class HoverTranslationManager extends ResourceTracker {
     const scope = settingsManager.get('MOUSE_HOVER_SCOPE', 'sentence');
     const detection = HoverTextDetector.detect(event.clientX, event.clientY, scope);
 
-    if (!detection) {
-      logger.debug('No text detected at cursor position during processing');
-      // If we've moved to empty space, ensure tooltip is hidden
-      this._handleMouseOut();
-      return;
-    }
+    if (!detection || !detection.text) {
+      // If we are over a "dead zone", we only close if we are actually outside the tolerance 
+      // of our last valid rectangle. This prevents flickering in gaps.
+      if (this.currentRect) {
+        const tolerance = COORDINATE_TOLERANCE;
+        const isStillInside = (
+          event.clientX >= this.currentRect.left - tolerance &&
+          event.clientX <= this.currentRect.right + tolerance &&
+          event.clientY >= this.currentRect.top - tolerance &&
+          event.clientY <= this.currentRect.bottom + tolerance
+        );
+        if (isStillInside) return;
+      }
 
-    if (!detection.text) {
       this._handleMouseOut();
       return;
     }
 
     if (detection.text === this.currentText) {
-      logger.debug('Detected text is the same as current, skipping');
+      // Refresh rectangle cache based on scope
+      this.currentRect = scope === 'container' 
+        ? detection.element.getBoundingClientRect()
+        : detection.rect;
       return;
     }
 
     logger.info(`Hover translation triggered for: "${detection.text.substring(0, 50)}..."`);
     this.currentText = detection.text;
-    this.currentRect = detection.rect; // Cache the rectangle for future movement checks
+    
+    // Cache rectangle based on scope:
+    // - Word/Sentence: Use specific text rectangle for responsive closing.
+    // - Container: Use block container rectangle for stable viewing of large blocks.
+    this.currentRect = scope === 'container' 
+      ? detection.element.getBoundingClientRect()
+      : detection.rect;
+
     const element = detection.element;
 
     // Clean up any previous border before applying new one
@@ -274,11 +292,22 @@ export class HoverTranslationManager extends ResourceTracker {
     // Use ResourceTracker to manage the element's mouseleave listener
     // This ensures cleanup if multiple hovers happen quickly or if the feature is deactivated
     const leaveHandler = (leaveEvent) => {
-      // If we're moving into a UI element (like the tooltip), don't close
-      if (leaveEvent.relatedTarget && ElementDetectionService.getInstance().isUIElement(leaveEvent.relatedTarget)) {
+      const relatedTarget = leaveEvent.relatedTarget;
+      const elementDetection = ElementDetectionService.getInstance();
+
+      // 1. If we're moving into a UI element (like the tooltip), don't close
+      if (relatedTarget && elementDetection.isUIElement(relatedTarget)) {
         return;
       }
 
+      // 2. If we are leaving the element but moving into another part of the same container
+      // (e.g. moving between nested spans), keep it open.
+      if (relatedTarget && element.contains(relatedTarget)) {
+        return;
+      }
+
+      // 3. Since 'element' is now always a stable block container (from HoverTextDetector),
+      // we can trust its 'mouseleave' event to signal a clear exit from the text block.
       this._removeBorder();
       this.handleMouseLeave();
     };

--- a/src/features/mouse-hover/HoverTranslationManager.js
+++ b/src/features/mouse-hover/HoverTranslationManager.js
@@ -227,8 +227,17 @@ export class HoverTranslationManager extends ResourceTracker {
   _removeBorder() {
     if (this.borderedElement) {
       this.borderedElement.style.outline = this.originalOutline || '';
+      this.borderedElement.style.outlineOffset = this.originalOutlineOffset || '';
+      this.borderedElement.style.boxShadow = this.originalBoxShadow || '';
+      this.borderedElement.style.transition = this.originalTransition || '';
+      this.borderedElement.style.borderRadius = this.originalBorderRadius || '';
+      
       this.borderedElement = null;
       this.originalOutline = null;
+      this.originalOutlineOffset = null;
+      this.originalBoxShadow = null;
+      this.originalTransition = null;
+      this.originalBorderRadius = null;
     }
   }
 
@@ -285,8 +294,17 @@ export class HoverTranslationManager extends ResourceTracker {
     if (scope === 'container' && settingsManager.get('MOUSE_HOVER_SHOW_CONTAINER_BORDER', true)) {
       this.borderedElement = element;
       this.originalOutline = element.style.outline;
-      element.style.outline = '2px solid var(--ti-primary-color, #4285f4)';
-      element.style.outlineOffset = '2px';
+      this.originalOutlineOffset = element.style.outlineOffset;
+      this.originalBoxShadow = element.style.boxShadow;
+      this.originalTransition = element.style.transition;
+      this.originalBorderRadius = element.style.borderRadius;
+
+      // Professional, subtle and rounded look with "breathing space"
+      element.style.outline = '1.5px solid var(--ti-primary-color, #4285f4)';
+      element.style.outlineOffset = '6px';
+      element.style.borderRadius = '8px'; // Rounded corners for a modern feel
+      element.style.boxShadow = '0 0 10px rgba(66, 133, 244, 0.15)';
+      element.style.transition = 'outline 0.2s ease, box-shadow 0.2s ease, outline-offset 0.2s ease, border-radius 0.2s ease';
     }
 
     // Use ResourceTracker to manage the element's mouseleave listener


### PR DESCRIPTION
## Description
This PR fixes the 'Mouse on Hover' flickering and premature closing bug while significantly improving the visual feedback for container selection.

### Key Changes
- **Fix Flickering**: Added a 10px coordinate tolerance to handleMouseMove to handle jitter and line-height gaps.
- **Stable Tracking**: mouseleave listeners are now attached to the nearest block-level container, providing a much more reliable exit signal.
- **Improved Modifier Logic**: Modifier keys (like Ctrl) now trigger the hover but don't close it when released, allowing for more natural interaction.
- **Professional Styling**: Updated the container border with a subtle 1.5px outline, 6px offset, 8px border-radius, and a soft glow effect with smooth transitions.
- **Scope-Aware Responsiveness**: Implemented precise closing logic for 'Word' and 'Sentence' scopes while keeping the 'Container' scope stable.