### PR TITLE
feat(auto-translate): extend exact-page rule controls to mobile UI

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -761,6 +761,27 @@
   "mobile_page_auto_close_tooltip": {
     "message": "Close dashboard automatically after starting translation"
   },
+  "mobile_page_auto_translate_label": {
+    "message": "Auto-Translate Page"
+  },
+  "mobile_page_auto_translate_desc_add": {
+    "message": "Automatically translate this exact page"
+  },
+  "mobile_page_auto_translate_desc_remove": {
+    "message": "This exact page will be auto-translated"
+  },
+  "mobile_page_auto_translate_desc_inherited": {
+    "message": "Controlled by a broader rule in settings"
+  },
+  "mobile_page_auto_translate_aria_add": {
+    "message": "Add this page to auto-translate rules"
+  },
+  "mobile_page_auto_translate_aria_remove": {
+    "message": "Remove this page from auto-translate rules"
+  },
+  "mobile_page_auto_translate_aria_inherited": {
+    "message": "This page is controlled by a broader auto-translate rule"
+  },
   "mobile_fab_alt": {
     "message": "Translate"
   },

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -761,6 +761,27 @@
   "mobile_page_auto_close_tooltip": {
     "message": "بستن خودکار دشبورد پس از شروع ترجمه"
   },
+  "mobile_page_auto_translate_label": {
+    "message": "ترجمه خودکار صفحه"
+  },
+  "mobile_page_auto_translate_desc_add": {
+    "message": "ترجمه خودکار این صفحه به‌محض ورود"
+  },
+  "mobile_page_auto_translate_desc_remove": {
+    "message": "این صفحه به طور خودکار ترجمه خواهد شد"
+  },
+  "mobile_page_auto_translate_desc_inherited": {
+    "message": "کنترل شده توسط یک قانون کلی در تنظیمات"
+  },
+  "mobile_page_auto_translate_aria_add": {
+    "message": "افزودن این صفحه به قوانین ترجمه خودکار"
+  },
+  "mobile_page_auto_translate_aria_remove": {
+    "message": "حذف این صفحه از قوانین ترجمه خودکار"
+  },
+  "mobile_page_auto_translate_aria_inherited": {
+    "message": "این صفحه توسط یک قانون کلی ترجمه خودکار کنترل می‌شود"
+  },
   "mobile_fab_alt": {
     "message": "ترجمه"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -758,6 +758,27 @@
   "mobile_page_auto_close_tooltip": {
     "message": "翻訳開始後にダッシュボードを自動的に閉じます"
   },
+  "mobile_page_auto_translate_label": {
+    "message": "ページの自動翻訳"
+  },
+  "mobile_page_auto_translate_desc_add": {
+    "message": "このページを自動的に翻訳します"
+  },
+  "mobile_page_auto_translate_desc_remove": {
+    "message": "このページは自動的に翻訳されます"
+  },
+  "mobile_page_auto_translate_desc_inherited": {
+    "message": "設定内の広範なルールによって制御されています"
+  },
+  "mobile_page_auto_translate_aria_add": {
+    "message": "このページを自動翻訳ルールに追加"
+  },
+  "mobile_page_auto_translate_aria_remove": {
+    "message": "このページを自動翻訳ルールから削除"
+  },
+  "mobile_page_auto_translate_aria_inherited": {
+    "message": "このページは広範な自動翻訳ルールによって制御されています"
+  },
   "mobile_fab_alt": {
     "message": "翻訳"
   },

--- a/src/apps/content/components/mobile/views/PageTranslationView.scss
+++ b/src/apps/content/components/mobile/views/PageTranslationView.scss
@@ -11,6 +11,44 @@
   box-sizing: border-box !important;
   width: 100% !important;
   overflow-x: hidden !important;
+
+  .ti-m-setting-star-btn {
+    width: 44px !important;
+    height: 44px !important;
+    border-radius: 50% !important;
+    background: none !important;
+    border: none !important;
+    cursor: pointer !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    color: var(--ti-mobile-text-muted, #64748b) !important;
+    -webkit-tap-highlight-color: transparent !important;
+    transition: all 0.2s ease !important;
+    padding: 0 !important;
+    margin: 0 !important;
+
+    svg {
+      display: block !important;
+    }
+
+    &:active {
+      transform: scale(0.92) !important;
+    }
+
+    &.is-active {
+      color: #ffb703 !important;
+    }
+
+    &.is-disabled {
+      opacity: 0.45 !important;
+      cursor: not-allowed !important;
+
+      &:active {
+        transform: none !important;
+      }
+    }
+  }
 }
 
 .ti-m-view-header {

--- a/src/apps/content/components/mobile/views/PageTranslationView.vue
+++ b/src/apps/content/components/mobile/views/PageTranslationView.vue
@@ -119,6 +119,43 @@
           <div class="ti-m-toggle-thumb" />
         </button>
       </div>
+
+      <!-- Settings Row (Exact Page Auto Translate) -->
+      <div 
+        v-if="isAutoTranslateToggleVisible"
+        class="ti-m-progress-settings-row"
+      >
+        <div class="ti-m-setting-info">
+          <span class="ti-m-setting-label">{{ t('mobile_page_auto_translate_label', 'Auto-Translate Page') }}</span>
+          <span class="ti-m-setting-desc">{{ autoTranslateToggleDesc }}</span>
+        </div>
+        <button 
+          class="ti-m-setting-star-btn"
+          :class="{ 
+            'is-active': isAutoTranslateToggleActive,
+            'is-disabled': isAutoTranslateToggleDisabled 
+          }"
+          :disabled="isAutoTranslateToggleDisabled"
+          :aria-label="autoTranslateToggleAria"
+          @click.stop="toggleAutoTranslateForCurrentPage"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            width="18"
+            height="18"
+            class="star-svg"
+          >
+            <path 
+              :fill="isAutoTranslateToggleActive ? 'currentColor' : 'none'" 
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linejoin="round"
+              stroke-linecap="round"
+              d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -140,6 +177,7 @@ import { MOBILE_CONSTANTS } from '@/shared/constants/mobile.js'
 import { getScopedLogger } from '@/shared/logging/logger.js'
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js'
 import PageTranslationStatus from '@/components/shared/PageTranslationStatus.vue'
+import { useAutoTranslateRules } from '@/features/page-translation/composables/useAutoTranslateRules.js'
 
 import wholePageIcon from '@/icons/ui/whole-page.png';
 import closeIcon from '@/icons/ui/close.png';
@@ -152,6 +190,33 @@ const { pageTranslationData } = storeToRefs(mobileStore)
 const { t } = useUnifiedI18n()
 const { handleError } = useErrorHandler();
 const logger = getScopedLogger(LOG_COMPONENTS.MOBILE, 'PageTranslationView')
+
+const currentUrl = computed(() => (typeof window !== 'undefined' ? window.location.href : ''));
+
+const {
+  isAutoTranslateToggleVisible,
+  isAutoTranslateToggleActive,
+  isAutoTranslateToggleDisabled,
+  toggleAutoTranslateForCurrentPage,
+} = useAutoTranslateRules({ currentUrl });
+
+const autoTranslateToggleDesc = computed(() => {
+  if (isAutoTranslateToggleDisabled.value) {
+    return t('mobile_page_auto_translate_desc_inherited', 'Controlled by a broader rule in settings');
+  }
+  return isAutoTranslateToggleActive.value
+    ? t('mobile_page_auto_translate_desc_remove', 'This exact page will be auto-translated')
+    : t('mobile_page_auto_translate_desc_add', 'Automatically translate this exact page');
+});
+
+const autoTranslateToggleAria = computed(() => {
+  if (isAutoTranslateToggleDisabled.value) {
+    return t('mobile_page_auto_translate_aria_inherited', 'This page is controlled by a broader auto-translate rule');
+  }
+  return isAutoTranslateToggleActive.value
+    ? t('mobile_page_auto_translate_aria_remove', 'Remove this page from auto-translate rules')
+    : t('mobile_page_auto_translate_aria_add', 'Add this page to auto-translate rules');
+});
 
 const pageProvider = computed(() => {
   return settingsStore.getEffectiveProvider(TranslationMode.Page);


### PR DESCRIPTION
## Summary

This PR extends the exact-page auto-translate rule controls to the Mobile Dashboard Page Translation view, bringing feature parity across Desktop FAB, Popup, and Mobile interfaces.

Users can now add or remove exact-page auto-translate rules directly from the mobile page translation screen without opening the settings page.

## Key Changes

### Mobile Auto-Translate Controls

* Added an exact-page auto-translate star toggle to the Mobile Dashboard Page Translation view.
* Supports adding and removing exact-page auto-translate rules.
* Uses touch-friendly controls and mobile-specific accessibility labels.
* Prevents page translation actions from being triggered when interacting with the rule toggle.

### Shared Rule Management

* Reuses the existing `useAutoTranslateRules` composable.
* Preserves consistent behavior across Mobile, Popup, and Desktop FAB.

### UX Improvements

* Exact rule:

  * active star
  * tap to remove
* No matching rule:

  * inactive star
  * tap to add
* Wildcard/non-exact match:

  * active but disabled star
  * clearly indicates the page is controlled by a broader rule

### Localization

* Added mobile-specific labels, descriptions, and accessibility strings.

### Testing

* Added mobile test coverage for visibility, state handling, and interaction behavior.
