### PR TITLE
feat(language-selector): support setting current languages as defaults

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3,6 +3,7 @@
 ##### Added
 
 - Added [auto-translate rule](#/activation?highlight=WHOLE_PAGE_AUTO_TRANSLATE_RULES) toggle to both FAB Desktop, Mobile and Popup translation controls.
+- Added the ability to set the current source and target languages as defaults directly from Popup, Sidepanel, and Mobile language selectors.
 
 ---
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1403,6 +1403,12 @@
   "popup_source_language_title": {
     "message": "Source language"
   },
+  "popup_set_source_language_default_title": {
+    "message": "Set current source language as default"
+  },
+  "popup_set_target_language_default_title": {
+    "message": "Set current target language as default"
+  },
   "popup_clear_source_language_title": {
     "message": "Clear source language"
   },
@@ -1537,6 +1543,12 @@
   },
   "SIDEPANEL_TARGET_LANGUAGE_TITLE": {
     "message": "Target Language"
+  },
+  "sidepanel_set_source_language_default_title": {
+    "message": "Set current source language as default"
+  },
+  "sidepanel_set_target_language_default_title": {
+    "message": "Set current target language as default"
   },
   "SIDEPANEL_COPY_SOURCE_ALT_ICON": {
     "message": "Copy"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -1403,6 +1403,12 @@
   "popup_source_language_title": {
     "message": "زبان مبدا"
   },
+  "popup_set_source_language_default_title": {
+    "message": "زبان مبدا فعلی را به‌عنوان پیش‌فرض ذخیره کن"
+  },
+  "popup_set_target_language_default_title": {
+    "message": "زبان مقصد فعلی را به‌عنوان پیش‌فرض ذخیره کن"
+  },
   "popup_clear_source_language_title": {
     "message": "پاک کردن مبدا"
   },
@@ -1537,6 +1543,12 @@
   },
   "SIDEPANEL_TARGET_LANGUAGE_TITLE": {
     "message": "زبان مقصد"
+  },
+  "sidepanel_set_source_language_default_title": {
+    "message": "زبان مبدا فعلی را به‌عنوان پیش‌فرض ذخیره کن"
+  },
+  "sidepanel_set_target_language_default_title": {
+    "message": "زبان مقصد فعلی را به‌عنوان پیش‌فرض ذخیره کن"
   },
   "SIDEPANEL_COPY_SOURCE_ALT_ICON": {
     "message": "کپی"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1403,6 +1403,12 @@
   "popup_source_language_title": {
     "message": "翻訳元言語"
   },
+  "popup_set_source_language_default_title": {
+    "message": "現在の翻訳元言語を既定として保存"
+  },
+  "popup_set_target_language_default_title": {
+    "message": "現在の翻訳先言語を既定として保存"
+  },
   "popup_clear_source_language_title": {
     "message": "翻訳元言語をクリア"
   },
@@ -1537,6 +1543,12 @@
   },
   "SIDEPANEL_TARGET_LANGUAGE_TITLE": {
     "message": "翻訳先言語"
+  },
+  "sidepanel_set_source_language_default_title": {
+    "message": "現在の翻訳元言語を既定として保存"
+  },
+  "sidepanel_set_target_language_default_title": {
+    "message": "現在の翻訳先言語を既定として保存"
   },
   "SIDEPANEL_COPY_SOURCE_ALT_ICON": {
     "message": "コピー"

--- a/src/apps/content/components/mobile/MobileSheet.test.js
+++ b/src/apps/content/components/mobile/MobileSheet.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { reactive, ref, nextTick } from 'vue'
+import MobileSheet from './MobileSheet.vue'
+
+let mockMobileStore
+let mockSettingsStore
+
+vi.mock('@/store/modules/mobile.js', () => ({
+  useMobileStore: () => mockMobileStore
+}))
+
+vi.mock('@/features/settings/stores/settings.js', () => ({
+  useSettingsStore: () => mockSettingsStore
+}))
+
+vi.mock('@/composables/core/useResourceTracker.js', () => ({
+  useResourceTracker: () => ({
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  })
+}))
+
+vi.mock('@/shared/messaging/core/UnifiedMessaging.js', () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/shared/messaging/core/MessageActions.js', () => ({
+  MessageActions: {
+    TTS_STOP: 'TTS_STOP'
+  }
+}))
+
+vi.mock('@/core/extensionContext.js', () => ({
+  default: {
+    isContextError: vi.fn(() => false)
+  }
+}))
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+vi.mock('@/shared/constants/mobile.js', () => ({
+  MOBILE_CONSTANTS: {
+    VIEWS: {
+      DASHBOARD: 'dashboard',
+      SELECTION: 'selection',
+      INPUT: 'input',
+      PAGE_TRANSLATION: 'page-translation',
+      HISTORY: 'history'
+    },
+    SHEET_STATE: {
+      PEEK: 'peek',
+      FULL: 'full',
+      CLOSED: 'closed'
+    }
+  }
+}))
+
+vi.mock('./views/DashboardView.vue', () => ({
+  default: {
+    name: 'DashboardView',
+    template: '<div class="dashboard-view-stub" />'
+  }
+}))
+
+vi.mock('./views/SelectionView.vue', () => ({
+  default: {
+    name: 'SelectionView',
+    template: '<div class="selection-view-stub" />'
+  }
+}))
+
+vi.mock('./views/InputView.vue', () => ({
+  default: {
+    name: 'InputView',
+    template: `
+      <div class="input-view-stub">
+        <select class="test-native-select">
+          <option value="en">English</option>
+        </select>
+        <div class="test-dead-zone">Dead zone</div>
+      </div>
+    `
+  }
+}))
+
+vi.mock('./views/PageTranslationView.vue', () => ({
+  default: {
+    name: 'PageTranslationView',
+    template: '<div class="page-translation-view-stub" />'
+  }
+}))
+
+vi.mock('./views/HistoryView.vue', () => ({
+  default: {
+    name: 'HistoryView',
+    template: '<div class="history-view-stub" />'
+  }
+}))
+
+describe('MobileSheet', () => {
+  beforeEach(() => {
+    mockMobileStore = reactive({
+      isOpen: ref(true),
+      activeView: ref('input'),
+      sheetState: ref('peek'),
+      isFullscreen: ref(false),
+      closeSheet: vi.fn(),
+      setSheetState: vi.fn(),
+      navigate: vi.fn()
+    })
+
+    mockSettingsStore = reactive({
+      isDarkTheme: false
+    })
+
+    window.matchMedia = vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }))
+
+    window.visualViewport = { height: 800 }
+    window.innerHeight = 800
+  })
+
+  afterEach(() => {
+    document.body.style.overflow = ''
+    document.body.style.touchAction = ''
+    document.documentElement.style.overflow = ''
+    delete window.visualViewport
+  })
+
+  it('allows native select controls to bypass sheet mousedown suppression', async () => {
+    const wrapper = mount(MobileSheet)
+    await nextTick()
+
+    const select = wrapper.get('.test-native-select').element
+    const event = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true
+    })
+
+    select.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('still suppresses mousedown on non-interactive sheet content', async () => {
+    const wrapper = mount(MobileSheet)
+    await nextTick()
+
+    const deadZone = wrapper.get('.test-dead-zone').element
+    const event = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true
+    })
+
+    deadZone.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/src/apps/content/components/mobile/MobileSheet.vue
+++ b/src/apps/content/components/mobile/MobileSheet.vue
@@ -216,14 +216,27 @@ const closeSheet = () => {
   mobileStore.closeSheet()
 }
 
+const isNativeInteractiveControl = (target) => {
+  if (!target) return false
+  if (target.isContentEditable) return true
+
+  const tagName = target.tagName
+  if (!tagName) return false
+
+  if (['TEXTAREA', 'INPUT', 'SELECT', 'OPTION'].includes(tagName)) {
+    return true
+  }
+
+  // Defensive: some browsers may surface option descendants when interacting with a select.
+  return typeof target.closest === 'function' && !!target.closest('select')
+}
+
 const onSheetMouseDown = (e) => {
   // CRITICAL: Prevent focus shift from page to sheet to preserve selection
   const target = e.target;
   
-  // 1. Identify interactive elements that MUST gain focus (text inputs)
-  const isFocusable = target.tagName === 'TEXTAREA' || 
-                      target.tagName === 'INPUT' || 
-                      target.isContentEditable;
+  // 1. Identify native interactive controls that must keep their browser behavior
+  const isFocusable = isNativeInteractiveControl(target);
   
   // 2. Identify elements that should trigger clicks (Buttons, Links, etc.)
   // We don't want to preventDefault on touchstart for these to allow the sequence to complete.

--- a/src/apps/content/components/mobile/views/InputView.test.js
+++ b/src/apps/content/components/mobile/views/InputView.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { reactive, ref, nextTick } from 'vue'
+import InputView from './InputView.vue'
+
+let mockMobileStore
+let mockSettingsStore
+let mockLanguageDefaults
+let mockTTSSmart
+
+vi.mock('@/store/modules/mobile.js', () => ({
+  useMobileStore: () => mockMobileStore
+}))
+
+vi.mock('@/features/settings/stores/settings.js', () => ({
+  useSettingsStore: () => mockSettingsStore
+}))
+
+vi.mock('@/features/settings/composables/useLanguageDefaults.js', () => ({
+  useLanguageDefaults: () => mockLanguageDefaults
+}))
+
+vi.mock('@/composables/shared/useUnifiedI18n.js', () => ({
+  useUnifiedI18n: () => ({
+    t: (key, fallback) => fallback || key
+  })
+}))
+
+vi.mock('@/shared/messaging/composables/useMessaging.js', () => ({
+  useMessaging: () => ({
+    sendMessage: vi.fn().mockResolvedValue({ success: true, result: { translatedText: 'hello' } }),
+    createMessage: vi.fn((action, payload) => ({ action, payload }))
+  })
+}))
+
+vi.mock('@/composables/shared/useErrorHandler.js', () => ({
+  useErrorHandler: () => ({
+    getErrorForDisplay: vi.fn().mockResolvedValue({ message: 'error' }),
+    handleError: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/features/tts/composables/useTTSSmart.js', () => ({
+  useTTSSmart: () => mockTTSSmart
+}))
+
+vi.mock('@/components/shared/TranslationDisplay.vue', () => ({
+  default: {
+    name: 'TranslationDisplay',
+    template: '<div class="translation-display-stub" />'
+  }
+}))
+
+vi.mock('@/components/shared/LanguageSelector.vue', () => ({
+  default: {
+    name: 'LanguageSelector',
+    props: [
+      'sourceLanguage',
+      'targetLanguage',
+      'provider',
+      'compact',
+      'beta',
+      'showDefaultActions',
+      'defaultActionsEnabled',
+      'sourceIsSavedDefault',
+      'targetIsSavedDefault',
+      'sourceDefaultTitle',
+      'targetDefaultTitle',
+      'sourceTitle',
+      'targetTitle',
+      'swapTitle',
+      'autoDetectLabel'
+    ],
+    emits: ['set-default-source', 'set-default-target'],
+    template: '<div class="language-selector-stub" />'
+  }
+}))
+
+vi.mock('@/components/shared/ProviderSelector.vue', () => ({
+  default: {
+    name: 'ProviderSelector',
+    template: '<div class="provider-selector-stub" />'
+  }
+}))
+
+vi.mock('@/core/PageEventBus.js', () => ({
+  pageEventBus: {
+    emit: vi.fn()
+  }
+}))
+
+vi.mock('@/shared/messaging/core/MessagingCore.js', () => ({
+  MessageActions: {
+    SHOW_NOTIFICATION_SIMPLE: 'SHOW_NOTIFICATION_SIMPLE',
+    TRANSLATE: 'TRANSLATE',
+    CANCEL_TRANSLATION: 'CANCEL_TRANSLATION'
+  },
+  MessageContexts: {
+    MOBILE_TRANSLATE: 'MOBILE_TRANSLATE'
+  }
+}))
+
+vi.mock('@/shared/utils/text/textAnalysis.js', () => ({
+  shouldApplyRtl: vi.fn(() => false)
+}))
+
+vi.mock('@/shared/constants/mobile.js', () => ({
+  MOBILE_CONSTANTS: {
+    VIEWS: {
+      DASHBOARD: 'dashboard',
+      HISTORY: 'history'
+    },
+    SHEET_STATE: {
+      FULL: 'full'
+    },
+    UI_MODE: {
+      AUTO: 'auto'
+    }
+  }
+}))
+
+vi.mock('@/shared/config/config.js', () => ({
+  TranslationMode: {
+    Dictionary_Translation: 'dictionary',
+    Mobile_Translate: 'mobile'
+  }
+}))
+
+vi.mock('@/core/extensionContext.js', () => ({
+  default: {
+    isContextError: vi.fn(() => false),
+    handleContextError: vi.fn()
+  }
+}))
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      getURL: vi.fn((path) => path)
+    }
+  }
+}))
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('InputView', () => {
+  beforeEach(() => {
+    mockMobileStore = reactive({
+      selectionData: {
+        text: 'hello',
+        sourceLang: 'fr',
+        targetLang: 'de',
+        translation: '',
+        mode: null,
+        error: ''
+      },
+      updateSelectionData: vi.fn(),
+      navigate: vi.fn(),
+      setSheetState: vi.fn(),
+      closeSheet: vi.fn(),
+      setView: vi.fn()
+    })
+
+    mockSettingsStore = reactive({
+      isDarkTheme: false,
+      isInitialized: false,
+      settings: {
+        DEEPL_BETA_LANGUAGES_ENABLED: false,
+        SOURCE_LANGUAGE: 'auto',
+        TARGET_LANGUAGE: 'en',
+        TRANSLATION_API: 'google'
+      }
+    })
+
+    mockLanguageDefaults = {
+      savedSourceLanguage: ref('auto'),
+      savedTargetLanguage: ref('en'),
+      isReady: ref(false),
+      setSourceLanguageAsDefault: vi.fn().mockResolvedValue(true),
+      setTargetLanguageAsDefault: vi.fn().mockResolvedValue(true)
+    }
+
+    mockTTSSmart = {
+      ttsState: ref('idle'),
+      stop: vi.fn(),
+      speak: vi.fn().mockResolvedValue(undefined)
+    }
+  })
+
+  it('disables default actions before settings are ready', async () => {
+    const wrapper = mount(InputView)
+    await flushPromises()
+    await nextTick()
+
+    const selector = wrapper.findComponent({ name: 'LanguageSelector' })
+    expect(selector.props('defaultActionsEnabled')).toBe(false)
+  })
+
+  it('enables default actions after settings become ready', async () => {
+    const wrapper = mount(InputView)
+    await flushPromises()
+    await nextTick()
+
+    mockLanguageDefaults.isReady.value = true
+    mockSettingsStore.isInitialized = true
+    await nextTick()
+
+    const selector = wrapper.findComponent({ name: 'LanguageSelector' })
+    expect(selector.props('defaultActionsEnabled')).toBe(true)
+  })
+
+  it('persists the current local language when a star is clicked', async () => {
+    const wrapper = mount(InputView)
+    await flushPromises()
+    await nextTick()
+
+    mockLanguageDefaults.isReady.value = true
+    mockSettingsStore.isInitialized = true
+    await nextTick()
+
+    const selector = wrapper.findComponent({ name: 'LanguageSelector' })
+    expect(selector.props('sourceLanguage')).toBe('fr')
+    expect(selector.props('targetLanguage')).toBe('de')
+
+    selector.vm.$emit('set-default-source')
+    selector.vm.$emit('set-default-target')
+    await flushPromises()
+
+    expect(mockLanguageDefaults.setSourceLanguageAsDefault).toHaveBeenCalledWith('fr')
+    expect(mockLanguageDefaults.setTargetLanguageAsDefault).toHaveBeenCalledWith('de')
+    expect(selector.props('sourceLanguage')).toBe('fr')
+    expect(selector.props('targetLanguage')).toBe('de')
+  })
+})

--- a/src/apps/content/components/mobile/views/InputView.vue
+++ b/src/apps/content/components/mobile/views/InputView.vue
@@ -79,10 +79,18 @@
           compact
           :provider="currentProvider"
           :beta="settingsStore.settings.DEEPL_BETA_LANGUAGES_ENABLED"
+          show-default-actions
+          :default-actions-enabled="isReady"
+          :source-is-saved-default="sourceIsSavedDefault"
+          :target-is-saved-default="targetIsSavedDefault"
+          :source-default-title="sourceDefaultTitle"
+          :target-default-title="targetDefaultTitle"
           :source-title="t('popup_source_language_title', 'Source')"
           :target-title="t('popup_target_language_title', 'Target')"
           :swap-title="t('popup_swap_languages_title', 'Swap')"
           :auto-detect-label="t('auto_detect', 'Auto-Detect')"
+          @set-default-source="handleSetDefaultSource"
+          @set-default-target="handleSetDefaultTarget"
         />
       </div>
       
@@ -147,6 +155,7 @@ import { ref, computed, watch } from 'vue'
 import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
 import { useMobileStore } from '@/store/modules/mobile.js'
 import { useSettingsStore } from '@/features/settings/stores/settings.js'
+import { useLanguageDefaults } from '@/features/settings/composables/useLanguageDefaults.js'
 import { pageEventBus } from '@/core/PageEventBus.js'
 import { useMessaging } from '@/shared/messaging/composables/useMessaging.js'
 import { MessageActions, MessageContexts } from '@/shared/messaging/core/MessagingCore.js'
@@ -166,9 +175,20 @@ const mobileStore = useMobileStore()
 const settingsStore = useSettingsStore()
 const { t } = useUnifiedI18n()
 const { sendMessage, createMessage } = useMessaging(MessageContexts.MOBILE_TRANSLATE)
-const { getErrorForDisplay } = useErrorHandler()
+const { getErrorForDisplay, handleError } = useErrorHandler()
 const tts = useTTSSmart()
 const logger = getScopedLogger(LOG_COMPONENTS.MOBILE, 'InputView')
+const {
+  savedSourceLanguage,
+  savedTargetLanguage,
+  isReady,
+  setSourceLanguageAsDefault,
+  setTargetLanguageAsDefault
+} = useLanguageDefaults()
+const sourceIsSavedDefault = computed(() => sourceLang.value === savedSourceLanguage.value)
+const targetIsSavedDefault = computed(() => targetLang.value === savedTargetLanguage.value)
+const sourceDefaultTitle = computed(() => t('mobile_set_source_language_default_title', 'Set current source language as default'))
+const targetDefaultTitle = computed(() => t('mobile_set_target_language_default_title', 'Set current target language as default'))
 
 const inputText = ref(mobileStore.selectionData.text || '')
 const sourceLang = ref(mobileStore.selectionData.sourceLang || settingsStore.settings.SOURCE_LANGUAGE || 'auto')
@@ -319,6 +339,24 @@ const handleCancel = async () => {
     await sendMessage(cancelMessage);
   } catch (error) {
     logger.error('Failed to send cancel message:', error);
+  }
+}
+
+const handleSetDefaultSource = async () => {
+  try {
+    await setSourceLanguageAsDefault(sourceLang.value)
+  } catch (error) {
+    await handleError(error, 'mobile-input-set-source-default')
+    logger.error('Failed to persist source language default', error)
+  }
+}
+
+const handleSetDefaultTarget = async () => {
+  try {
+    await setTargetLanguageAsDefault(targetLang.value)
+  } catch (error) {
+    await handleError(error, 'mobile-input-set-target-default')
+    logger.error('Failed to persist target language default', error)
   }
 }
 

--- a/src/apps/popup/PopupApp.test.js
+++ b/src/apps/popup/PopupApp.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import PopupApp from './PopupApp.vue'
+
+let mockSettingsStore
+let mockUnifiedTranslation
+let mockLanguageDefaults
+
+vi.mock('@/features/settings/stores/settings.js', () => ({
+  useSettingsStore: () => mockSettingsStore
+}))
+
+vi.mock('@/features/translation/composables/useUnifiedTranslation.js', () => ({
+  useUnifiedTranslation: () => mockUnifiedTranslation
+}))
+
+vi.mock('@/features/settings/composables/useLanguageDefaults.js', () => ({
+  useLanguageDefaults: () => mockLanguageDefaults
+}))
+
+vi.mock('@/shared/messaging/composables/useMessaging.js', () => ({
+  useMessaging: () => ({
+    sendMessage: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/shared/useErrorHandler.js', () => ({
+  useErrorHandler: () => ({
+    handleError: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/composables/shared/useUnifiedI18n.js', () => ({
+  useUnifiedI18n: () => ({
+    t: (key, fallback) => fallback || key
+  })
+}))
+
+vi.mock('@/features/tts/core/TTSGlobalManager.js', () => ({
+  useTTSGlobal: () => ({
+    register: vi.fn(),
+    unregister: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/core/useResourceTracker.js', () => ({
+  useResourceTracker: () => ({
+    trackTimeout: vi.fn(),
+    addEventListener: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/shared/useFont.js', () => ({
+  useGlobalFont: () => ({
+    applyGlobalCSSVariables: vi.fn()
+  })
+}))
+
+vi.mock('@/utils/UtilsFactory.js', () => ({
+  utilsFactory: {
+    getUIUtils: vi.fn().mockResolvedValue({
+      applyTheme: vi.fn().mockResolvedValue(undefined)
+    })
+  }
+}))
+
+vi.mock('@/composables/shared/useLanguages.js', () => ({
+  useLanguages: () => ({
+    loadLanguages: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/components/base/LoadingSpinner.vue', () => ({
+  default: {
+    name: 'LoadingSpinner',
+    template: '<div class="loading-spinner-stub" />'
+  }
+}))
+
+vi.mock('@/components/popup/PopupHeader.vue', () => ({
+  default: {
+    name: 'PopupHeader',
+    props: ['targetLanguage', 'provider'],
+    template: '<div class="popup-header-stub" />'
+  }
+}))
+
+vi.mock('@/components/shared/LanguageSelector.vue', () => ({
+  default: {
+    name: 'LanguageSelector',
+    props: [
+      'sourceLanguage',
+      'targetLanguage',
+      'provider',
+      'lastKeyword',
+      'beta',
+      'showDefaultActions',
+      'defaultActionsEnabled',
+      'sourceIsSavedDefault',
+      'targetIsSavedDefault',
+      'sourceDefaultTitle',
+      'targetDefaultTitle',
+      'sourceTitle',
+      'targetTitle',
+      'swapTitle',
+      'swapAlt',
+      'autoDetectLabel'
+    ],
+    emits: ['set-default-source', 'set-default-target', 'update:sourceLanguage', 'update:targetLanguage'],
+    template: '<div class="language-selector-stub" />'
+  }
+}))
+
+vi.mock('@/components/shared/ProviderSelector.vue', () => ({
+  default: {
+    name: 'ProviderSelector',
+    template: '<div class="provider-selector-stub" />'
+  }
+}))
+
+vi.mock('@/components/popup/TranslationForm.vue', () => ({
+  default: {
+    name: 'TranslationForm',
+    props: ['sourceLanguage', 'targetLanguage', 'provider'],
+    template: '<div class="translation-form-stub" />'
+  }
+}))
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      getURL: vi.fn((path) => path)
+    }
+  }
+}))
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('PopupApp', () => {
+  beforeEach(() => {
+    mockUnifiedTranslation = {
+      sourceLanguage: ref('fr'),
+      targetLanguage: ref('de'),
+      sourceText: ref('hello'),
+      translatedText: ref('bonjour'),
+      clearTranslation: vi.fn().mockResolvedValue(undefined),
+      lastTranslation: ref({ source: 'hello' })
+    }
+
+    mockLanguageDefaults = {
+      savedSourceLanguage: ref('fr'),
+      savedTargetLanguage: ref('en'),
+      isReady: ref(true),
+      setSourceLanguageAsDefault: vi.fn().mockResolvedValue(true),
+      setTargetLanguageAsDefault: vi.fn().mockResolvedValue(true)
+    }
+
+    mockSettingsStore = {
+      settings: {
+        DEEPL_BETA_LANGUAGES_ENABLED: false,
+        TRANSLATION_API: 'google',
+        THEME: 'auto'
+      },
+      loadSettings: vi.fn().mockResolvedValue(undefined),
+      isInitialized: true
+    }
+  })
+
+  it('passes default action props', async () => {
+    const wrapper = mount(PopupApp)
+    await flushPromises()
+    await flushPromises()
+
+    const selector = wrapper.findComponent({ name: 'LanguageSelector' })
+
+    expect(selector.exists()).toBe(true)
+    expect(selector.props('showDefaultActions')).not.toBe(false)
+    expect(selector.props('defaultActionsEnabled')).toBe(true)
+    expect(selector.props('sourceIsSavedDefault')).toBe(true)
+    expect(selector.props('targetIsSavedDefault')).toBe(false)
+  })
+
+  it('persists current source and target when stars are clicked', async () => {
+    const wrapper = mount(PopupApp)
+    await flushPromises()
+    await flushPromises()
+
+    const selector = wrapper.findComponent({ name: 'LanguageSelector' })
+
+    selector.vm.$emit('set-default-source')
+    selector.vm.$emit('set-default-target')
+    await flushPromises()
+
+    expect(mockLanguageDefaults.setSourceLanguageAsDefault).toHaveBeenCalledWith('fr')
+    expect(mockLanguageDefaults.setTargetLanguageAsDefault).toHaveBeenCalledWith('de')
+  })
+})

--- a/src/apps/popup/PopupApp.vue
+++ b/src/apps/popup/PopupApp.vue
@@ -61,11 +61,19 @@
               :provider="currentProvider"
               :last-keyword="lastTranslation?.source"
               :beta="settingsStore.settings.DEEPL_BETA_LANGUAGES_ENABLED"
+              show-default-actions
+              :default-actions-enabled="isReady"
+              :source-is-saved-default="sourceIsSavedDefault"
+              :target-is-saved-default="targetIsSavedDefault"
+              :source-default-title="sourceDefaultTitle"
+              :target-default-title="targetDefaultTitle"
               :source-title="t('popup_source_language_title') || 'زبان مبدا'"
               :target-title="t('popup_target_language_title') || 'زبان مقصد'"
               :swap-title="t('popup_swap_languages_title') || 'جابجایی زبان‌ها'"
               :swap-alt="t('popup_swap_languages_alt_icon') || 'Swap'"
               :auto-detect-label="'Auto-Detect'"
+              @set-default-source="handleSetDefaultSource"
+              @set-default-target="handleSetDefaultTarget"
             />
 
             <!-- Clear Button: Minimized clear fields button -->
@@ -117,6 +125,7 @@ import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
 import { useTTSGlobal } from '@/features/tts/core/TTSGlobalManager.js';
 import { useResourceTracker } from '@/composables/core/useResourceTracker.js'
 import { useUnifiedTranslation } from '@/features/translation/composables/useUnifiedTranslation.js';
+import { useLanguageDefaults } from '@/features/settings/composables/useLanguageDefaults.js'
 import { MessageActions } from '@/shared/messaging/core/MessageActions.js';
 import { MessageContexts } from '@/shared/messaging/core/MessagingConstants.js';
 import { matchErrorToType } from '@/shared/error-management/ErrorMatcher.js';
@@ -152,6 +161,17 @@ const {
   clearTranslation,
   lastTranslation
 } = useUnifiedTranslation('popup');
+const {
+  savedSourceLanguage,
+  savedTargetLanguage,
+  isReady,
+  setSourceLanguageAsDefault,
+  setTargetLanguageAsDefault
+} = useLanguageDefaults()
+const sourceIsSavedDefault = computed(() => sourceLanguage.value === savedSourceLanguage.value)
+const targetIsSavedDefault = computed(() => targetLanguage.value === savedTargetLanguage.value)
+const sourceDefaultTitle = computed(() => t('popup_set_source_language_default_title', 'Set current source language as default'))
+const targetDefaultTitle = computed(() => t('popup_set_target_language_default_title', 'Set current target language as default'))
 
 // TTS Global Manager for cross-context lifecycle management
 const ttsGlobal = useTTSGlobal({ 
@@ -214,6 +234,22 @@ const handleClearFields = async () => {
   // Also dispatch global event if other components rely on it
   const event = new CustomEvent('clear-storage');
   document.dispatchEvent(event);
+}
+
+const handleSetDefaultSource = async () => {
+  try {
+    await setSourceLanguageAsDefault(sourceLanguage.value)
+  } catch (error) {
+    await handleError(error, 'popup-set-source-default')
+  }
+}
+
+const handleSetDefaultTarget = async () => {
+  try {
+    await setTargetLanguageAsDefault(targetLanguage.value)
+  } catch (error) {
+    await handleError(error, 'popup-set-target-default')
+  }
 }
 
 /**

--- a/src/apps/sidepanel/components/SidepanelMainContent.test.js
+++ b/src/apps/sidepanel/components/SidepanelMainContent.test.js
@@ -31,6 +31,14 @@ const mockUnifiedTranslation = {
   loadLastTranslation: vi.fn().mockResolvedValue(undefined),
 };
 
+const mockLanguageDefaults = {
+  savedSourceLanguage: ref('en'),
+  savedTargetLanguage: ref('fa'),
+  isReady: ref(true),
+  setSourceLanguageAsDefault: vi.fn().mockResolvedValue(true),
+  setTargetLanguageAsDefault: vi.fn().mockResolvedValue(true),
+};
+
 vi.mock('@/features/translation/composables/useUnifiedTranslation.js', () => ({
   useUnifiedTranslation: () => mockUnifiedTranslation,
 }));
@@ -55,9 +63,32 @@ vi.mock('@/features/settings/stores/settings.js', () => ({
   }),
 }));
 
+vi.mock('@/features/settings/composables/useLanguageDefaults.js', () => ({
+  useLanguageDefaults: () => mockLanguageDefaults,
+}));
+
 vi.mock('@/components/shared/LanguageSelector.vue', () => ({
   default: {
     name: 'LanguageSelector',
+    props: [
+      'sourceLanguage',
+      'targetLanguage',
+      'provider',
+      'lastKeyword',
+      'beta',
+      'showDefaultActions',
+      'defaultActionsEnabled',
+      'sourceIsSavedDefault',
+      'targetIsSavedDefault',
+      'sourceDefaultTitle',
+      'targetDefaultTitle',
+      'sourceTitle',
+      'targetTitle',
+      'swapTitle',
+      'swapAlt',
+      'autoDetectLabel'
+    ],
+    emits: ['set-default-source', 'set-default-target'],
     template: '<div class="language-selector-stub" />',
   },
 }));
@@ -115,5 +146,27 @@ describe('SidepanelMainContent.vue', () => {
       sourceLanguage: 'en',
       targetLanguage: 'fa',
     }));
+  });
+
+  it('passes default action props and forwards star events', async () => {
+    const wrapper = mount(SidepanelMainContent, {
+      props: {
+        provider: '',
+      },
+    });
+
+    const selector = wrapper.findComponent({ name: 'LanguageSelector' });
+    expect(selector.props('showDefaultActions')).not.toBe(false);
+    expect(selector.props('defaultActionsEnabled')).toBe(true);
+    expect(selector.props('sourceIsSavedDefault')).toBe(true);
+    expect(selector.props('targetIsSavedDefault')).toBe(true);
+
+    selector.vm.$emit('set-default-source');
+    selector.vm.$emit('set-default-target');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockLanguageDefaults.setSourceLanguageAsDefault).toHaveBeenCalledWith('en');
+    expect(mockLanguageDefaults.setTargetLanguageAsDefault).toHaveBeenCalledWith('fa');
   });
 });

--- a/src/apps/sidepanel/components/SidepanelMainContent.vue
+++ b/src/apps/sidepanel/components/SidepanelMainContent.vue
@@ -14,11 +14,19 @@
           :provider="currentProviderLocal"
           :last-keyword="lastTranslation?.source"
           :beta="settingsStore.settings.DEEPL_BETA_LANGUAGES_ENABLED"
+          show-default-actions
+          :default-actions-enabled="isReady"
+          :source-is-saved-default="sourceIsSavedDefault"
+          :target-is-saved-default="targetIsSavedDefault"
+          :source-default-title="sourceDefaultTitle"
+          :target-default-title="targetDefaultTitle"
           :source-title="t('SIDEPANEL_SOURCE_LANGUAGE_TITLE', 'زبان مبدا')"
           :target-title="t('SIDEPANEL_TARGET_LANGUAGE_TITLE', 'زبان مقصد')"
           :swap-title="t('SIDEPANEL_SWAP_LANGUAGES_TITLE', 'جابجایی زبان‌ها')"
           :swap-alt="t('SIDEPANEL_SWAP_LANGUAGES_ALT', 'Swap')"
           :auto-detect-label="'Auto-Detect'"
+          @set-default-source="handleSetDefaultSource"
+          @set-default-target="handleSetDefaultTarget"
         />
 
         <!-- Translate Button (shown alongside language selectors in wide layout) -->
@@ -142,6 +150,7 @@
 import './SidepanelMainContent.scss'
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useUnifiedTranslation } from '@/features/translation/composables/useUnifiedTranslation.js'
+import { useLanguageDefaults } from '@/features/settings/composables/useLanguageDefaults.js'
 import { useErrorHandler } from '@/composables/shared/useErrorHandler.js'
 import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
 import { useSettingsStore } from '@/features/settings/stores/settings.js'
@@ -182,6 +191,17 @@ const {
   clearTranslation,
   loadLastTranslation
 } = useUnifiedTranslation('sidepanel');
+const {
+  savedSourceLanguage,
+  savedTargetLanguage,
+  isReady,
+  setSourceLanguageAsDefault,
+  setTargetLanguageAsDefault
+} = useLanguageDefaults()
+const sourceIsSavedDefault = computed(() => sourceLanguage.value === savedSourceLanguage.value)
+const targetIsSavedDefault = computed(() => targetLanguage.value === savedTargetLanguage.value)
+const sourceDefaultTitle = computed(() => t('sidepanel_set_source_language_default_title', 'Set current source language as default'))
+const targetDefaultTitle = computed(() => t('sidepanel_set_target_language_default_title', 'Set current target language as default'))
 const { handleError } = useErrorHandler()
 
 // Refs
@@ -315,6 +335,22 @@ const clearFields = async () => {
   logger.debug("Clearing fields and resetting languages");
   await clearTranslation();
 };
+
+const handleSetDefaultSource = async () => {
+  try {
+    await setSourceLanguageAsDefault(sourceLanguage.value)
+  } catch (error) {
+    await handleError(error, 'sidepanel-set-source-default')
+  }
+}
+
+const handleSetDefaultTarget = async () => {
+  try {
+    await setTargetLanguageAsDefault(targetLanguage.value)
+  } catch (error) {
+    await handleError(error, 'sidepanel-set-target-default')
+  }
+}
 
 // Expose methods and refs to the parent component
 defineExpose({

--- a/src/components/shared/LanguageSelector.scss
+++ b/src/components/shared/LanguageSelector.scss
@@ -12,6 +12,21 @@
   margin: 8px 12px 0 12px !important;
   box-sizing: border-box !important;
 
+  .ti-language-control-group {
+    display: flex !important;
+    align-items: center !important;
+    gap: 4px !important;
+    min-width: 0 !important;
+  }
+
+  .ti-language-control-shell {
+    position: relative !important;
+    display: flex !important;
+    align-items: center !important;
+    min-width: 0 !important;
+    flex: 1 1 auto !important;
+  }
+
   /* Vertical layout for small sidepanel widths */
   &.ti-language-controls--vertical {
     flex-direction: column !important;
@@ -20,21 +35,35 @@
     padding: 4px 12px !important;
     min-height: fit-content !important;
 
-    .ti-language-select {
+    .ti-language-control-group {
       width: 100% !important;
       max-width: none !important;
       min-width: auto !important;
-      order: 1 !important;
 
-      &:first-of-type {
-        order: 3 !important;
+      .ti-language-control-shell {
+        width: 100% !important;
       }
+
+      .ti-language-select {
+        width: 100% !important;
+        max-width: none !important;
+        min-width: 0 !important;
+        flex: 1 1 auto !important;
+      }
+    }
+
+    .ti-language-control-group--source {
+      order: 1 !important;
     }
 
     .ti-swap-button {
       order: 2 !important;
       align-self: center !important;
       margin: 1px 0 !important;
+    }
+
+    .ti-language-control-group--target {
+      order: 3 !important;
     }
   }
 
@@ -85,6 +114,16 @@
         filter: var(--ti-mobile-icon-filter, none) !important;
       }
     }
+
+    .ti-language-control-group--with-default-action .ti-language-select {
+      padding-inline-end: 34px !important;
+    }
+
+    .ti-default-action-button {
+      width: 22px !important;
+      height: 22px !important;
+      min-width: 22px !important;
+    }
   }
 }
 
@@ -127,6 +166,61 @@
     color: var(--text-disabled, #6c757d) !important;
     cursor: not-allowed !important;
   }
+
+  .ti-language-control-group--with-default-action & {
+    padding-inline-end: 2.5rem !important;
+  }
+
+  .ti-compact-mode .ti-language-control-group--with-default-action & {
+    padding-inline-end: 2.25rem !important;
+  }
+}
+
+.ti-default-action-button {
+  position: absolute !important;
+  inset-inline-end: 6px !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 22px !important;
+  height: 22px !important;
+  min-width: 22px !important;
+  padding: 0 !important;
+  border: 1px solid transparent !important;
+  border-radius: 4px !important;
+  background: transparent !important;
+  color: var(--text-secondary, #6c757d) !important;
+  cursor: pointer !important;
+  flex-shrink: 0 !important;
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease !important;
+  z-index: 1 !important;
+
+  &:hover:not(:disabled) {
+    background-color: var(--toolbar-link-hover-bg-color, rgba(0, 0, 0, 0.05)) !important;
+    color: var(--primary-color, #007bff) !important;
+  }
+
+  &.is-active {
+    color: var(--primary-color, #007bff) !important;
+  }
+
+  &:disabled {
+    cursor: not-allowed !important;
+    opacity: 0.45 !important;
+  }
+
+  &:focus {
+    outline: none !important;
+    border-color: var(--primary-color, #007bff) !important;
+  }
+}
+
+.ti-default-action-icon {
+  display: inline-block !important;
+  font-size: 14px !important;
+  line-height: 1 !important;
 }
 
 .ti-swap-button {

--- a/src/components/shared/LanguageSelector.scss
+++ b/src/components/shared/LanguageSelector.scss
@@ -120,18 +120,33 @@
       }
     }
 
-    .ti-language-control-group--with-default-action .ti-language-select {
-      padding-inline-end: calc(
-        var(--ti-language-select-default-action-inline-end) +
-        var(--ti-language-select-default-action-width) +
-        var(--ti-language-select-default-action-gap)
-      ) !important;
+    .ti-language-control-group--with-default-action {
+      width: 100% !important;
+
+      .ti-language-control-shell {
+        width: 100% !important;
+        gap: 4px !important;
+      }
+
+      .ti-language-select {
+        flex: 1 1 auto !important;
+        max-width: none !important;
+        min-width: 0 !important;
+        padding-inline-end: 25px !important;
+      }
     }
 
     .ti-default-action-button {
       width: var(--ti-language-select-default-action-width) !important;
       height: var(--ti-language-select-default-action-width) !important;
       min-width: var(--ti-language-select-default-action-width) !important;
+      position: static !important;
+      inset-inline-end: auto !important;
+      top: auto !important;
+      transform: none !important;
+      z-index: auto !important;
+      margin-inline-start: 0 !important;
+      flex: 0 0 auto !important;
     }
   }
 }

--- a/src/components/shared/LanguageSelector.scss
+++ b/src/components/shared/LanguageSelector.scss
@@ -11,6 +11,11 @@
   background: var(--language-controls-bg-color, transparent) !important;
   margin: 8px 12px 0 12px !important;
   box-sizing: border-box !important;
+  --ti-language-select-arrow-inline-end: 8px;
+  --ti-language-select-arrow-width: 10px;
+  --ti-language-select-default-action-width: 22px;
+  --ti-language-select-default-action-gap: 2px;
+  --ti-language-select-default-action-inline-end: 18px;
 
   .ti-language-control-group {
     display: flex !important;
@@ -44,11 +49,11 @@
         width: 100% !important;
       }
 
-      .ti-language-select {
-        width: 100% !important;
-        max-width: none !important;
-        min-width: 0 !important;
-        flex: 1 1 auto !important;
+    .ti-language-select {
+      width: 100% !important;
+      max-width: none !important;
+      min-width: 0 !important;
+      flex: 1 1 auto !important;
       }
     }
 
@@ -87,7 +92,7 @@
       font-size: 15px !important;
       padding: 0 10px !important;
       color: var(--ti-mobile-text-secondary, #1c7ed6) !important;
-      background-position: right 8px center !important;
+      background-position: right var(--ti-language-select-arrow-inline-end) center !important;
       background-size: 10px 5px !important;
 
       option {
@@ -116,13 +121,17 @@
     }
 
     .ti-language-control-group--with-default-action .ti-language-select {
-      padding-inline-end: 34px !important;
+      padding-inline-end: calc(
+        var(--ti-language-select-default-action-inline-end) +
+        var(--ti-language-select-default-action-width) +
+        var(--ti-language-select-default-action-gap)
+      ) !important;
     }
 
     .ti-default-action-button {
-      width: 22px !important;
-      height: 22px !important;
-      min-width: 22px !important;
+      width: var(--ti-language-select-default-action-width) !important;
+      height: var(--ti-language-select-default-action-width) !important;
+      min-width: var(--ti-language-select-default-action-width) !important;
     }
   }
 }
@@ -141,8 +150,8 @@
   appearance: none !important;
   -webkit-appearance: none !important;
   background-repeat: no-repeat !important;
-  background-position: right 8px center !important;
-  background-size: 10px 5px !important;
+  background-position: right var(--ti-language-select-arrow-inline-end) center !important;
+  background-size: var(--ti-language-select-arrow-width) 5px !important;
   padding-right: 25px !important;
   vertical-align: middle !important;
   cursor: pointer !important;
@@ -168,25 +177,33 @@
   }
 
   .ti-language-control-group--with-default-action & {
-    padding-inline-end: 2.5rem !important;
+    padding-inline-end: calc(
+      var(--ti-language-select-default-action-inline-end) +
+      var(--ti-language-select-default-action-width) +
+      var(--ti-language-select-default-action-gap)
+    ) !important;
   }
 
   .ti-compact-mode .ti-language-control-group--with-default-action & {
-    padding-inline-end: 2.25rem !important;
+    padding-inline-end: calc(
+      var(--ti-language-select-default-action-inline-end) +
+      var(--ti-language-select-default-action-width) +
+      var(--ti-language-select-default-action-gap)
+    ) !important;
   }
 }
 
 .ti-default-action-button {
   position: absolute !important;
-  inset-inline-end: 6px !important;
+  inset-inline-end: var(--ti-language-select-default-action-inline-end) !important;
   top: 50% !important;
   transform: translateY(-50%) !important;
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
-  width: 22px !important;
-  height: 22px !important;
-  min-width: 22px !important;
+  width: var(--ti-language-select-default-action-width) !important;
+  height: var(--ti-language-select-default-action-width) !important;
+  min-width: var(--ti-language-select-default-action-width) !important;
   padding: 0 !important;
   border: 1px solid transparent !important;
   border-radius: 4px !important;
@@ -311,10 +328,20 @@
   }
 
   .ti-language-select {
-    padding: 0 22px 0 6px !important;
+    padding-block: 0 !important;
+    padding-inline-start: 6px !important;
+    padding-inline-end: 22px !important;
     font-size: 13px !important;
     max-width: 110px !important;
     height: 28px !important;
+  }
+
+  .ti-language-control-group--with-default-action .ti-language-select {
+    padding-inline-end: calc(
+      var(--ti-language-select-default-action-inline-end) +
+      var(--ti-language-select-default-action-width) +
+      var(--ti-language-select-default-action-gap)
+    ) !important;
   }
 
   .ti-swap-button {
@@ -348,11 +375,21 @@
   }
 
   .ti-language-select {
-    padding: 4px 30px 4px 10px !important;
+    padding-block: 4px !important;
+    padding-inline-start: 10px !important;
+    padding-inline-end: 30px !important;
     font-size: 14px !important;
     height: 34px !important;
     max-width: 140px !important;
     line-height: 1.4 !important;
+  }
+
+  .ti-language-control-group--with-default-action .ti-language-select {
+    padding-inline-end: calc(
+      var(--ti-language-select-default-action-inline-end) +
+      var(--ti-language-select-default-action-width) +
+      var(--ti-language-select-default-action-gap)
+    ) !important;
   }
 
   .ti-swap-button {
@@ -369,13 +406,13 @@
 /* RTL Adjustments */
 :is([dir="rtl"], html[dir="rtl"]) {
   .ti-language-select {
-    background-position: left 8px center !important;
-    padding-right: 8px !important;
-    padding-left: 25px !important;
+    background-position: left var(--ti-language-select-arrow-inline-end) center !important;
+    padding-inline-start: 25px !important;
+    padding-inline-end: 8px !important;
   }
   
   .ti-compact-mode .ti-language-select {
-    background-position: left 8px center !important;
+    background-position: left var(--ti-language-select-arrow-inline-end) center !important;
   }
 }
 

--- a/src/components/shared/LanguageSelector.test.js
+++ b/src/components/shared/LanguageSelector.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import LanguageSelector from './LanguageSelector.vue'
+
+const mockLanguages = ref([
+  { code: 'en', name: 'English' },
+  { code: 'fa', name: 'Persian' },
+  { code: 'fr', name: 'French' }
+])
+
+vi.mock('@/composables/shared/useLanguages.js', () => ({
+  useLanguages: () => ({
+    allLanguages: mockLanguages,
+    isLoaded: ref(true),
+    loadLanguages: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/composables/shared/useErrorHandler.js', () => ({
+  useErrorHandler: () => ({
+    handleError: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/shared/useUnifiedI18n.js', () => ({
+  useUnifiedI18n: () => ({
+    t: (key, fallback) => fallback || key
+  })
+}))
+
+vi.mock('@/features/translation/composables/useTranslationModes.js', () => ({
+  useSelectElementTranslation: () => ({
+    isSelectModeActive: ref(false),
+    deactivateSelectMode: vi.fn()
+  })
+}))
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+vi.mock('@/shared/config/languageConstants.js', () => ({
+  PROVIDER_SUPPORTED_LANGUAGES: {},
+  PROVIDER_LANGUAGE_PAIRS: {},
+  getProviderLanguageCode: (code) => code
+}))
+
+vi.mock('@/features/translation/providers/ProviderManifest.js', () => ({
+  findProviderById: () => null
+}))
+
+vi.mock('@/shared/config/config.js', () => ({
+  CONFIG: {
+    TARGET_LANGUAGE: 'en'
+  }
+}))
+
+vi.mock('@/utils/UtilsFactory.js', () => ({
+  utilsFactory: {
+    getI18nUtils: vi.fn().mockResolvedValue({
+      findLanguageCode: vi.fn((value) => Promise.resolve(value))
+    })
+  }
+}))
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      getURL: vi.fn((path) => path)
+    }
+  }
+}))
+
+describe('LanguageSelector', () => {
+  beforeEach(() => {
+    global.ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+  })
+
+  afterEach(() => {
+    delete global.ResizeObserver
+  })
+
+  const mountSelector = (props = {}) => mount(LanguageSelector, {
+    props: {
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      provider: '',
+      ...props
+    }
+  })
+
+  it('hides stars by default', () => {
+    const wrapper = mountSelector()
+    expect(wrapper.findAll('.ti-default-action-button')).toHaveLength(0)
+  })
+
+  it('shows stars when enabled', () => {
+    const wrapper = mountSelector({
+      showDefaultActions: true
+    })
+
+    expect(wrapper.findAll('.ti-default-action-button')).toHaveLength(2)
+  })
+
+  it('reflects filled and empty states from props', () => {
+    const wrapper = mountSelector({
+      showDefaultActions: true,
+      sourceIsSavedDefault: true,
+      targetIsSavedDefault: false,
+      sourceDefaultTitle: 'Source default',
+      targetDefaultTitle: 'Target default'
+    })
+
+    expect(wrapper.get('button[title="Source default"]').text()).toContain('★')
+    expect(wrapper.get('button[title="Target default"]').text()).toContain('☆')
+  })
+
+  it('disables star buttons when defaultActionsEnabled is false', () => {
+    const wrapper = mountSelector({
+      showDefaultActions: true,
+      defaultActionsEnabled: false
+    })
+
+    const buttons = wrapper.findAll('.ti-default-action-button')
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0].attributes('disabled')).toBeDefined()
+    expect(buttons[1].attributes('disabled')).toBeDefined()
+  })
+
+  it('emits set-default-source when the source star is clicked', async () => {
+    const wrapper = mountSelector({
+      showDefaultActions: true,
+      sourceDefaultTitle: 'Source default',
+      targetDefaultTitle: 'Target default'
+    })
+
+    await wrapper.get('button[title="Source default"]').trigger('click')
+
+    expect(wrapper.emitted('set-default-source')).toHaveLength(1)
+  })
+
+  it('emits set-default-target when the target star is clicked', async () => {
+    const wrapper = mountSelector({
+      showDefaultActions: true,
+      sourceDefaultTitle: 'Source default',
+      targetDefaultTitle: 'Target default'
+    })
+
+    await wrapper.get('button[title="Target default"]').trigger('click')
+
+    expect(wrapper.emitted('set-default-target')).toHaveLength(1)
+  })
+})

--- a/src/components/shared/LanguageSelector.vue
+++ b/src/components/shared/LanguageSelector.vue
@@ -10,21 +10,43 @@
     <!-- Regular Language Selection -->
     <template v-if="!isAutoLanguageProvider">
       <!-- Target Language Dropdown -->
-      <select
-        v-model="targetLanguage"
-        class="ti-language-select"
-        :title="targetTitle"
-        :disabled="disabled"
-        @click="handleDropdownClick"
+      <div
+        class="ti-language-control-group ti-language-control-group--target"
+        :class="{ 'ti-language-control-group--with-default-action': showDefaultActions }"
       >
-        <option
-          v-for="language in targetLanguages"
-          :key="language.code"
-          :value="language.code"
+        <div class="ti-language-control-shell">
+        <select
+          v-model="targetLanguage"
+          class="ti-language-select"
+          :title="targetTitle"
+          :disabled="disabled"
+          @click="handleDropdownClick"
         >
-          {{ language.name }}
-        </option>
-      </select>
+          <option
+            v-for="language in targetLanguages"
+            :key="language.code"
+            :value="language.code"
+          >
+            {{ language.name }}
+          </option>
+        </select>
+          <button
+            v-if="showDefaultActions"
+            type="button"
+            class="ti-default-action-button"
+            :class="{ 'is-active': targetIsSavedDefault }"
+            :title="targetDefaultTitle || 'Set target as default'"
+            :aria-label="targetDefaultTitle || 'Set target as default'"
+            :disabled="disabled || !defaultActionsEnabled"
+            @click="emit('set-default-target')"
+          >
+            <span
+              aria-hidden="true"
+              class="ti-default-action-icon"
+            >{{ targetIsSavedDefault ? '★' : '☆' }}</span>
+          </button>
+        </div>
+      </div>
 
       <!-- Swap Button -->
       <button
@@ -42,34 +64,56 @@
       </button>
 
       <!-- Source Language Dropdown -->
-      <select
-        v-model="sourceLanguage"
-        class="ti-language-select"
-        :title="sourceTitle"
-        :disabled="disabled"
-        @click="handleDropdownClick"
+      <div
+        class="ti-language-control-group ti-language-control-group--source"
+        :class="{ 'ti-language-control-group--with-default-action': showDefaultActions }"
       >
-        <option 
-          v-if="!sourceLanguage" 
-          value="" 
-          disabled
+        <div class="ti-language-control-shell">
+        <select
+          v-model="sourceLanguage"
+          class="ti-language-select"
+          :title="sourceTitle"
+          :disabled="disabled"
+          @click="handleDropdownClick"
         >
-          {{ t('select_language_placeholder') || 'Select Language' }}
-        </option>
-        <option 
-          v-if="hasAutoDetect && allowAuto"
-          value="auto"
-        >
-          {{ autoDetectLabel }}
-        </option>
-        <option
-          v-for="language in availableLanguages"
-          :key="language.code"
-          :value="language.code"
-        >
-          {{ language.name }}
-        </option>
-      </select>
+          <option 
+            v-if="!sourceLanguage" 
+            value="" 
+            disabled
+          >
+            {{ t('select_language_placeholder') || 'Select Language' }}
+          </option>
+          <option 
+            v-if="hasAutoDetect && allowAuto"
+            value="auto"
+          >
+            {{ autoDetectLabel }}
+          </option>
+          <option
+            v-for="language in availableLanguages"
+            :key="language.code"
+            :value="language.code"
+          >
+            {{ language.name }}
+          </option>
+        </select>
+          <button
+            v-if="showDefaultActions"
+            type="button"
+            class="ti-default-action-button"
+            :class="{ 'is-active': sourceIsSavedDefault }"
+            :title="sourceDefaultTitle || 'Set source as default'"
+            :aria-label="sourceDefaultTitle || 'Set source as default'"
+            :disabled="disabled || !defaultActionsEnabled"
+            @click="emit('set-default-source')"
+          >
+            <span
+              aria-hidden="true"
+              class="ti-default-action-icon"
+            >{{ sourceIsSavedDefault ? '★' : '☆' }}</span>
+          </button>
+        </div>
+      </div>
     </template>
 
     <!-- Smart Language Indicator (e.g. for Vajehyab) -->
@@ -149,6 +193,22 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  showDefaultActions: {
+    type: Boolean,
+    default: false
+  },
+  defaultActionsEnabled: {
+    type: Boolean,
+    default: true
+  },
+  sourceIsSavedDefault: {
+    type: Boolean,
+    default: false
+  },
+  targetIsSavedDefault: {
+    type: Boolean,
+    default: false
+  },
   // i18n labels
   autoDetectLabel: {
     type: String,
@@ -169,6 +229,14 @@ const props = defineProps({
   swapAlt: {
     type: String,
     default: 'Swap'
+  },
+  sourceDefaultTitle: {
+    type: String,
+    default: ''
+  },
+  targetDefaultTitle: {
+    type: String,
+    default: ''
   },
   autoLanguageLabel: {
     type: String,
@@ -192,7 +260,9 @@ const props = defineProps({
 const emit = defineEmits([
   'update:sourceLanguage',
   'update:targetLanguage',
-  'swap-languages'
+  'swap-languages',
+  'set-default-source',
+  'set-default-target'
 ])
 
 // Computed

--- a/src/components/shared/LanguageSelector.vue
+++ b/src/components/shared/LanguageSelector.vue
@@ -15,21 +15,21 @@
         :class="{ 'ti-language-control-group--with-default-action': showDefaultActions }"
       >
         <div class="ti-language-control-shell">
-        <select
-          v-model="targetLanguage"
-          class="ti-language-select"
-          :title="targetTitle"
-          :disabled="disabled"
-          @click="handleDropdownClick"
-        >
-          <option
-            v-for="language in targetLanguages"
-            :key="language.code"
-            :value="language.code"
+          <select
+            v-model="targetLanguage"
+            class="ti-language-select"
+            :title="targetTitle"
+            :disabled="disabled"
+            @click="handleDropdownClick"
           >
-            {{ language.name }}
-          </option>
-        </select>
+            <option
+              v-for="language in targetLanguages"
+              :key="language.code"
+              :value="language.code"
+            >
+              {{ language.name }}
+            </option>
+          </select>
           <button
             v-if="showDefaultActions"
             type="button"
@@ -69,34 +69,34 @@
         :class="{ 'ti-language-control-group--with-default-action': showDefaultActions }"
       >
         <div class="ti-language-control-shell">
-        <select
-          v-model="sourceLanguage"
-          class="ti-language-select"
-          :title="sourceTitle"
-          :disabled="disabled"
-          @click="handleDropdownClick"
-        >
-          <option 
-            v-if="!sourceLanguage" 
-            value="" 
-            disabled
+          <select
+            v-model="sourceLanguage"
+            class="ti-language-select"
+            :title="sourceTitle"
+            :disabled="disabled"
+            @click="handleDropdownClick"
           >
-            {{ t('select_language_placeholder') || 'Select Language' }}
-          </option>
-          <option 
-            v-if="hasAutoDetect && allowAuto"
-            value="auto"
-          >
-            {{ autoDetectLabel }}
-          </option>
-          <option
-            v-for="language in availableLanguages"
-            :key="language.code"
-            :value="language.code"
-          >
-            {{ language.name }}
-          </option>
-        </select>
+            <option 
+              v-if="!sourceLanguage" 
+              value="" 
+              disabled
+            >
+              {{ t('select_language_placeholder') || 'Select Language' }}
+            </option>
+            <option 
+              v-if="hasAutoDetect && allowAuto"
+              value="auto"
+            >
+              {{ autoDetectLabel }}
+            </option>
+            <option
+              v-for="language in availableLanguages"
+              :key="language.code"
+              :value="language.code"
+            >
+              {{ language.name }}
+            </option>
+          </select>
           <button
             v-if="showDefaultActions"
             type="button"

--- a/src/features/settings/composables/useLanguageDefaults.js
+++ b/src/features/settings/composables/useLanguageDefaults.js
@@ -1,0 +1,40 @@
+import { computed } from 'vue'
+import { useSettingsStore } from '@/features/settings/stores/settings.js'
+
+/**
+ * Composable for persisting the currently selected translation languages
+ * as the user's stored defaults.
+ */
+export function useLanguageDefaults() {
+  const settingsStore = useSettingsStore()
+
+  const savedSourceLanguage = computed(() => settingsStore.settings?.SOURCE_LANGUAGE)
+  const savedTargetLanguage = computed(() => settingsStore.settings?.TARGET_LANGUAGE)
+  const isReady = computed(() => settingsStore.isInitialized)
+
+  const persistLanguageDefault = async (key, language) => {
+    const previousValue = settingsStore.settings?.[key]
+
+    try {
+      await settingsStore.updateSettingAndPersist(key, language)
+      return true
+    } catch (error) {
+      // Revert the optimistic local store mutation so the UI only reflects
+      // a saved default after persistence succeeds.
+      settingsStore.updateSettingLocally(key, previousValue)
+      throw error
+    }
+  }
+
+  const setSourceLanguageAsDefault = (language) => persistLanguageDefault('SOURCE_LANGUAGE', language)
+  const setTargetLanguageAsDefault = (language) => persistLanguageDefault('TARGET_LANGUAGE', language)
+
+  return {
+    savedSourceLanguage,
+    savedTargetLanguage,
+    isReady,
+    setSourceLanguageAsDefault,
+    setTargetLanguageAsDefault
+  }
+}
+

--- a/src/features/settings/composables/useLanguageDefaults.js
+++ b/src/features/settings/composables/useLanguageDefaults.js
@@ -7,21 +7,29 @@ import { useSettingsStore } from '@/features/settings/stores/settings.js'
  */
 export function useLanguageDefaults() {
   const settingsStore = useSettingsStore()
+  const requestTokens = {
+    SOURCE_LANGUAGE: 0,
+    TARGET_LANGUAGE: 0
+  }
 
   const savedSourceLanguage = computed(() => settingsStore.settings?.SOURCE_LANGUAGE)
   const savedTargetLanguage = computed(() => settingsStore.settings?.TARGET_LANGUAGE)
   const isReady = computed(() => settingsStore.isInitialized)
 
   const persistLanguageDefault = async (key, language) => {
+    const requestToken = (requestTokens[key] || 0) + 1
+    requestTokens[key] = requestToken
     const previousValue = settingsStore.settings?.[key]
 
     try {
       await settingsStore.updateSettingAndPersist(key, language)
       return true
     } catch (error) {
-      // Revert the optimistic local store mutation so the UI only reflects
-      // a saved default after persistence succeeds.
-      settingsStore.updateSettingLocally(key, previousValue)
+      // Only roll back if this request is still the latest write for the key.
+      // Older failures must not overwrite a newer successful default.
+      if (requestTokens[key] === requestToken) {
+        settingsStore.updateSettingLocally(key, previousValue)
+      }
       throw error
     }
   }
@@ -37,4 +45,3 @@ export function useLanguageDefaults() {
     setTargetLanguageAsDefault
   }
 }
-

--- a/src/features/settings/composables/useLanguageDefaults.test.js
+++ b/src/features/settings/composables/useLanguageDefaults.test.js
@@ -26,6 +26,26 @@ describe('useLanguageDefaults', () => {
     })
   })
 
+  const useDeferredPersistence = () => {
+    const persistCalls = []
+
+    mockSettingsStore.updateSettingAndPersist = vi.fn((key, value) => {
+      mockSettingsStore.settings[key] = value
+      let resolve
+      let reject
+
+      const promise = new Promise((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+
+      persistCalls.push({ key, value, resolve, reject })
+      return promise
+    })
+
+    return persistCalls
+  }
+
   const withSetup = () => {
     let result
     const app = createApp({
@@ -63,6 +83,65 @@ describe('useLanguageDefaults', () => {
     expect(mockSettingsStore.updateSettingAndPersist).toHaveBeenCalledWith('TARGET_LANGUAGE', 'de')
     expect(mockSettingsStore.settings.TARGET_LANGUAGE).toBe('de')
     expect(composable.savedTargetLanguage.value).toBe('de')
+  })
+
+  it('rolls back a failed single request to the previous value', async () => {
+    const composable = withSetup()
+    const persistCalls = useDeferredPersistence()
+    const request = composable.setSourceLanguageAsDefault('fr')
+
+    expect(mockSettingsStore.settings.SOURCE_LANGUAGE).toBe('fr')
+    expect(persistCalls).toHaveLength(1)
+
+    persistCalls[0].reject(new Error('save failed'))
+
+    await expect(request).rejects.toThrow('save failed')
+    await nextTick()
+
+    expect(mockSettingsStore.updateSettingLocally).toHaveBeenCalledWith('SOURCE_LANGUAGE', 'auto')
+    expect(mockSettingsStore.settings.SOURCE_LANGUAGE).toBe('auto')
+  })
+
+  it('does not roll back an older failed SOURCE_LANGUAGE request over a newer success', async () => {
+    const composable = withSetup()
+    const persistCalls = useDeferredPersistence()
+    const olderRequest = composable.setSourceLanguageAsDefault('fr')
+    const newerRequest = composable.setSourceLanguageAsDefault('de')
+
+    expect(mockSettingsStore.settings.SOURCE_LANGUAGE).toBe('de')
+    expect(persistCalls).toHaveLength(2)
+
+    persistCalls[1].resolve(true)
+    await newerRequest
+
+    persistCalls[0].reject(new Error('older request failed'))
+    await expect(olderRequest).rejects.toThrow('older request failed')
+    await nextTick()
+
+    expect(mockSettingsStore.updateSettingLocally).not.toHaveBeenCalled()
+    expect(mockSettingsStore.settings.SOURCE_LANGUAGE).toBe('de')
+  })
+
+  it('keeps SOURCE_LANGUAGE and TARGET_LANGUAGE requests independent', async () => {
+    const composable = withSetup()
+    const persistCalls = useDeferredPersistence()
+    const sourceRequest = composable.setSourceLanguageAsDefault('fr')
+    const targetRequest = composable.setTargetLanguageAsDefault('de')
+
+    expect(mockSettingsStore.settings.SOURCE_LANGUAGE).toBe('fr')
+    expect(mockSettingsStore.settings.TARGET_LANGUAGE).toBe('de')
+    expect(persistCalls).toHaveLength(2)
+
+    persistCalls[1].resolve(true)
+    await targetRequest
+
+    persistCalls[0].reject(new Error('source request failed'))
+    await expect(sourceRequest).rejects.toThrow('source request failed')
+    await nextTick()
+
+    expect(mockSettingsStore.updateSettingLocally).toHaveBeenCalledWith('SOURCE_LANGUAGE', 'auto')
+    expect(mockSettingsStore.settings.SOURCE_LANGUAGE).toBe('auto')
+    expect(mockSettingsStore.settings.TARGET_LANGUAGE).toBe('de')
   })
 
   it('isReady follows settingsStore.isInitialized', async () => {

--- a/src/features/settings/composables/useLanguageDefaults.test.js
+++ b/src/features/settings/composables/useLanguageDefaults.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createApp, nextTick, reactive } from 'vue'
+import { useLanguageDefaults } from './useLanguageDefaults.js'
+
+let mockSettingsStore
+
+vi.mock('@/features/settings/stores/settings.js', () => ({
+  useSettingsStore: () => mockSettingsStore
+}))
+
+describe('useLanguageDefaults', () => {
+  beforeEach(() => {
+    mockSettingsStore = reactive({
+      settings: {
+        SOURCE_LANGUAGE: 'auto',
+        TARGET_LANGUAGE: 'en'
+      },
+      isInitialized: false,
+      updateSettingAndPersist: vi.fn(async (key, value) => {
+        mockSettingsStore.settings[key] = value
+        return true
+      }),
+      updateSettingLocally: vi.fn((key, value) => {
+        mockSettingsStore.settings[key] = value
+      })
+    })
+  })
+
+  const withSetup = () => {
+    let result
+    const app = createApp({
+      setup() {
+        result = useLanguageDefaults()
+        return () => null
+      }
+    })
+    const host = document.createElement('div')
+    app.mount(host)
+    return result
+  }
+
+  it('exposes saved defaults from settings store', async () => {
+    const composable = withSetup()
+    await nextTick()
+
+    expect(composable.savedSourceLanguage.value).toBe('auto')
+    expect(composable.savedTargetLanguage.value).toBe('en')
+  })
+
+  it('persists SOURCE_LANGUAGE', async () => {
+    const composable = withSetup()
+    await composable.setSourceLanguageAsDefault('fr')
+
+    expect(mockSettingsStore.updateSettingAndPersist).toHaveBeenCalledWith('SOURCE_LANGUAGE', 'fr')
+    expect(mockSettingsStore.settings.SOURCE_LANGUAGE).toBe('fr')
+    expect(composable.savedSourceLanguage.value).toBe('fr')
+  })
+
+  it('persists TARGET_LANGUAGE', async () => {
+    const composable = withSetup()
+    await composable.setTargetLanguageAsDefault('de')
+
+    expect(mockSettingsStore.updateSettingAndPersist).toHaveBeenCalledWith('TARGET_LANGUAGE', 'de')
+    expect(mockSettingsStore.settings.TARGET_LANGUAGE).toBe('de')
+    expect(composable.savedTargetLanguage.value).toBe('de')
+  })
+
+  it('isReady follows settingsStore.isInitialized', async () => {
+    const composable = withSetup()
+
+    expect(composable.isReady.value).toBe(false)
+
+    mockSettingsStore.isInitialized = true
+    await nextTick()
+
+    expect(composable.isReady.value).toBe(true)
+  })
+})


### PR DESCRIPTION
This PR adds default language management directly to the language selector UI and enables users to persist their current source and target language selections without visiting the Settings page.

### Highlights

#### Default Language Actions

* Added default-language actions to the shared `LanguageSelector` component.
* Users can save the currently selected source or target language as their default.
* Enabled in:

  * Popup
  * Sidepanel
  * Mobile Input View
* Subtitle UI remains unchanged.

#### Language Selector UI

* Embedded the default-language action inside the selector control.
* Refined selector layout to reserve separate space for:

  * language label
  * default-language action
  * dropdown arrow
* Improved compact, mobile, sidepanel, and RTL layout behavior.

#### Settings Integration

* Added `useLanguageDefaults` composable for default-language persistence.
* Kept persistence logic outside `LanguageSelector` to preserve component boundaries.
* Reused existing settings storage and synchronization flows.

#### Reliability

* Fixed a stale rollback race condition during concurrent default-language updates.
* Added last-write-wins protection for default-language persistence.

#### Tests

* Added unit coverage for:

  * `useLanguageDefaults`
  * `LanguageSelector`
  * Popup integration
  * Sidepanel integration
  * Mobile integration
* Added regression coverage for default-language persistence race conditions.
