### PR TITLE
feat(markdown): modern markdown rendering and history previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Comprehensive documentation is available in the `docs/` folder:
 - [**MessagingSystem.md**](docs/technical/MessagingSystem.md): **Messaging System** – Race-condition-free communication.
 - [**TRANSLATION_SYSTEM.md**](docs/technical/TRANSLATION_SYSTEM.md): **Translation Service** – Coordination and result routing.
 - [**PROVIDERS.md**](docs/technical/PROVIDERS.md): **Provider Implementation Guide** – BaseProvider and Circuit Breaker.
+- [**MARKDOWN_RENDERING.md**](docs/technical/MARKDOWN_RENDERING.md): Markdown rendering, preview pipeline, TTS extraction boundaries, and provider Markdown contracts.
 - [**ERROR_MANAGEMENT_SYSTEM.md**](docs/technical/ERROR_MANAGEMENT_SYSTEM.md): Centralized error management and context safety.
 - [**STORAGE_MANAGER.md**](docs/technical/STORAGE_MANAGER.md): **StorageCore Guide** – Unified storage API with caching.
 - [**LOGGING_SYSTEM.md**](docs/technical/LOGGING_SYSTEM.md): **Structured Logging** – Component-based levels and performance.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,7 @@
 
 - Added [auto-translate rule](#/activation?highlight=WHOLE_PAGE_AUTO_TRANSLATE_RULES) toggle to both FAB Desktop, Mobile and Popup translation controls.
 - Added the ability to set the current source and target languages as defaults directly from Popup, Sidepanel, and Mobile language selectors.
+- Added modern Markdown rendering support for translation results and history entries, with improved dictionary formatting and pronunciation display.
 
 ---
 

--- a/docs/technical/ARCHITECTURE.md
+++ b/docs/technical/ARCHITECTURE.md
@@ -18,6 +18,7 @@
 - **[Messaging System](MessagingSystem.md)** - Race-condition-free inter-component communication with intelligent timeout management and Unified Translation Service integration
 - **[Translation System](TRANSLATION_SYSTEM.md)** - Unified Translation Service architecture with centralized coordination, duplicate prevention, and intelligent result routing
 - **[Provider Implementation Guide](PROVIDERS.md)** - Complete guide for implementing translation providers with BaseProvider, RateLimitManager, and Circuit Breaker
+- **[Markdown Rendering](MARKDOWN_RENDERING.md)** - Shared preview pipeline, SafeMarkdownPreview boundary, and extraction ownership
 - **[Error Management](ERROR_MANAGEMENT_SYSTEM.md)** - Centralized error handling and context safety
 - **[Testing Strategy](TESTING_STRATEGY.md)** - Guidelines and roadmap for unit and integration testing
 - **[Storage Manager](STORAGE_MANAGER.md)** - Unified storage API with caching and events
@@ -698,6 +699,8 @@ For implementation details and code examples, refer to the following system guid
 - **Shared Components**: Reusable feature-specific components that encapsulate common logic (e.g., `TranslationDisplay`).
 - **Layout Components**: Manage structural concerns and responsive positioning across different extension contexts.
 
+Markdown rendering for `TranslationDisplay` and history previews is centralized in `src/shared/utils/text/markdownPreview.js`. Providers must emit Markdown or plain text only and must not own final HTML shaping.
+
 ### Documentation
 For detailed information on UI hosting and in-page integration, refer to the following guides:
 - **[UI Host System Documentation](UI_HOST_SYSTEM.md)**
@@ -797,6 +800,7 @@ For detailed information on UI hosting and in-page integration, refer to the fol
 
 ### Shared Components
 - `src/components/shared/TranslationDisplay.vue` - Translation result display
+- `src/components/shared/SafeMarkdownPreview.vue` - Controlled markdown HTML boundary for sanitized preview output
 - `src/components/shared/TranslationInputField.vue` - Translation input
 - `src/components/shared/actions/ActionToolbar.vue` - Action toolbar
 - `src/components/shared/LanguageSelector.vue` - Language selection

--- a/docs/technical/MARKDOWN_RENDERING.md
+++ b/docs/technical/MARKDOWN_RENDERING.md
@@ -1,0 +1,139 @@
+# Markdown Rendering Architecture
+
+## Overview
+
+Translate-It now uses a shared markdown rendering architecture for user-facing previews and a separate extraction path for plain-text cleanup.
+
+The key design rule is simple:
+
+- Providers emit raw translation content and Markdown shape only.
+- UI rendering is handled by a shared preview pipeline.
+- Cleanup, copy, TTS, and export extraction stay in `SimpleMarkdown`.
+
+This keeps display concerns, text extraction concerns, and provider contracts isolated from one another.
+
+## Ownership Boundaries
+
+### Providers
+- Providers own the translation payload and its markdown structure.
+- Providers must not emit HTML.
+- Providers should use markdown conventions that the UI can render consistently:
+  - bold-label sections for dictionary entries
+  - inline code for IPA / pronunciation snippets
+  - plain markdown paragraphs, lists, headings, and code fences where appropriate
+
+### Shared preview renderer
+- `renderMarkdownPreview()` owns safe UI markdown rendering.
+- It is the shared display pipeline for:
+  - `TranslationDisplay`
+  - Sidepanel history previews
+  - Mobile history previews
+- It is responsible for:
+  - `marked` parsing
+  - DOMPurify sanitization
+  - legacy `SimpleMarkdown` fallback rendering when needed
+  - link normalization
+  - dictionary label/list grouping
+  - whitespace cleanup
+  - per-block direction normalization
+
+### Safe HTML boundary
+- `SafeMarkdownPreview` owns the only controlled `v-html` sink in the UI.
+- The component must only receive sanitized HTML produced by `renderMarkdownPreview()`.
+
+### Cleanup and extraction
+- `SimpleMarkdown` owns:
+  - legacy fallback extraction
+  - plain-text cleanup for copy/TTS/export
+  - pronunciation-guide stripping
+  - dictionary primary-text extraction
+- `SimpleMarkdown` is not the UI markdown renderer.
+
+## Rendering Pipeline
+
+The shared markdown preview pipeline is:
+
+1. Receive provider output or history text.
+2. Decide whether modern markdown rendering is appropriate.
+3. Render markdown with `marked` when possible.
+4. Sanitize the output with DOMPurify.
+5. Parse the sanitized markup in a detached DOM.
+6. Apply structural normalization:
+   - label/list grouping
+   - whitespace text-node cleanup
+   - direction normalization
+7. Re-sanitize the final HTML.
+8. Pass the sanitized result to `SafeMarkdownPreview`.
+
+If the content matches a legacy dictionary shape, the helper falls back to the legacy `SimpleMarkdown` path to preserve compatibility.
+
+## History Rendering
+
+Translation history stores raw text and preserves the original markdown-rich translation payload.
+
+- `sourceText` remains plain text in history views.
+- `translatedText` is rendered through the shared preview pipeline only.
+- History views do not own markdown parsing or sanitization.
+
+Exports remain independent from display rendering:
+
+- `json_raw` preserves the raw stored content.
+- `json_clean`, `csv`, and `anki` use cleaned plain-text extraction.
+
+## Cleanup, Copy, TTS, and Export
+
+Text extraction must stay in `SimpleMarkdown`.
+
+Use `SimpleMarkdown` for:
+
+- copy cleanup
+- TTS text extraction
+- export cleaning
+- dictionary primary-text extraction
+- pronunciation guide stripping
+- legacy plain-text fallback
+
+Dictionary mode should use the primary-only extraction strategy so pronunciation and metadata do not leak into spoken or copied text.
+
+## Provider Markdown Contract
+
+Providers must follow a markdown-first, HTML-free contract:
+
+- emit Markdown or plain text only
+- never emit HTML
+- use bold-label markdown for dictionary sections
+- use inline code for pronunciation / IPA snippets
+- avoid display-specific wrappers or UI-specific formatting
+- keep pronunciation metadata in display text only when that metadata is part of the provider contract
+
+New provider output shapes must be validated in:
+
+- provider contract tests
+- preview rendering tests
+- extraction tests when the output affects copy/TTS/export behavior
+
+## Testing Checklist
+
+When changing provider markdown or preview behavior, verify:
+
+- provider output matches the expected markdown contract
+- `renderMarkdownPreview()` renders the intended HTML
+- `SafeMarkdownPreview` remains the only `v-html` sink
+- history previews still render only `translatedText`
+- `SimpleMarkdown` still strips/normalizes the expected plain text
+- TTS still speaks the intended text only
+- export modes still produce the expected raw or cleaned output
+- dictionary sections still render correctly in Google, Vajehyab, and AI output
+- pronunciation / IPA lines still preserve inline code rendering in display mode
+- Prefer MockProvider fixtures for UI rendering regressions because they provide deterministic markdown samples that can be exercised consistently across TranslationDisplay, History previews, TTS extraction, and future UI surfaces.
+
+## Future Maintenance Notes
+
+- Keep preview rendering and text extraction separate.
+- Do not move display formatting logic back into providers.
+- Add new markdown patterns to the shared preview helper first, not to the history views.
+- Add new cleanup rules to `SimpleMarkdown` only when they affect copy/TTS/export extraction.
+- If a new provider introduces a special dictionary shape, add:
+  - a provider fixture
+  - a preview rendering test
+  - an extraction test if the text is meant for TTS or copy

--- a/docs/technical/PROVIDERS.md
+++ b/docs/technical/PROVIDERS.md
@@ -38,6 +38,23 @@ To prevent runtime crashes (like "split is not a function"), all providers (via 
 }
 ```
 
+## Markdown Output Contract
+
+Providers that emit dictionary-style or rich formatted output must follow a markdown-first contract:
+
+- emit Markdown or plain text only
+- never emit HTML
+- use bold-label Markdown for dictionary sections
+- use inline code for pronunciation / IPA snippets
+- avoid display-specific wrappers or layout-driven formatting
+- keep pronunciation metadata in the provider output only when it is part of the source content contract
+
+New provider dictionary shapes must be covered by:
+
+- provider contract tests
+- markdown preview rendering tests
+- extraction tests when the output affects TTS, copy, or export behavior
+
 ---
 
 ## Modularized Utilities (`src/features/translation/providers/utils/`)

--- a/docs/technical/TESTING_STRATEGY.md
+++ b/docs/technical/TESTING_STRATEGY.md
@@ -79,6 +79,14 @@ Testing translation providers (Gemini, OpenAI, Google).
 - **Focus**: Payload construction and result parsing.
 - **Standard**: Mock the `fetch` or `ProviderRequestEngine` to return specific JSON artifacts.
 
+### E. Markdown Rendering & Extraction
+Testing the shared markdown preview and cleanup pipeline.
+- **Provider contract tests**: Verify Google, Vajehyab, and AI providers emit the expected markdown shapes.
+- **Preview rendering tests**: Verify `renderMarkdownPreview()` and `TranslationDisplay` render markdown safely and preserve dictionary/list/IPA structures.
+- **History preview tests**: Verify Sidepanel and Mobile history render only `translatedText` through the shared preview path.
+- **Extraction tests**: Verify `SimpleMarkdown` continues to power copy, export, and TTS cleanup behavior.
+- **Regression fixtures**: Use `MockProvider` samples to reproduce UI regressions such as IPA lines and dictionary label/list blocks.
+
 ---
 
 ## Handling Edge Cases

--- a/docs/technical/TTS_SYSTEM.md
+++ b/docs/technical/TTS_SYSTEM.md
@@ -123,6 +123,11 @@ When searching for a voice, the system follows this priority:
 2.  **Neural Family Match**: Finds any available Neural voice in the same language group.
 3.  **Static Fallback**: Uses the hardcoded mapping in `ttsProviders.js` as a last resort.
 
+### Text Normalization for Speech
+- TTS uses `SimpleMarkdown.getCleanTranslation(...)` for the final speakable text.
+- Dictionary mode uses the `PRIMARY_ONLY` extraction strategy so pronunciation and metadata do not leak into speech.
+- Pronunciation-guide cleanup belongs in `SimpleMarkdown`, not in the display rendering pipeline.
+
 ---
 
 ## Lifecycle & State Management

--- a/src/apps/content/components/mobile/views/HistoryView.test.js
+++ b/src/apps/content/components/mobile/views/HistoryView.test.js
@@ -70,18 +70,44 @@ vi.mock('@/shared/logging/logger.js', () => ({
 describe('HistoryView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHistory.historyItems.value = [
+      {
+        sourceText: 'source text',
+        translatedText: vajehyabMarkdown,
+        sourceLanguage: 'fa',
+        targetLanguage: 'en',
+        timestamp: 0,
+        mode: 'dictionary',
+      },
+    ];
   });
 
-  it('displays translated text as plain truncated text, not rich HTML', async () => {
+  it('renders translated text as sanitized markdown preview while keeping source text plain', async () => {
+    const wrapper = mount(HistoryView);
+    await flushPromises();
+
+    const sourceText = wrapper.find('.ti-m-source-preview');
+    const translatedText = wrapper.find('.ti-m-target-preview');
+    expect(sourceText.exists()).toBe(true);
+    expect(sourceText.text()).toBe('source text');
+    expect(translatedText.exists()).toBe(true);
+    expect(translatedText.find('h3').exists()).toBe(true);
+    expect(translatedText.find('em').exists()).toBe(true);
+    expect(translatedText.html()).toContain('<strong>معنی</strong>');
+    expect(translatedText.html()).not.toContain('###');
+  });
+
+  it('sanitizes unsafe markdown/html in translated text previews', async () => {
+    mockHistory.historyItems.value[0].translatedText = '<img src=x onerror=alert(1)>';
+
     const wrapper = mount(HistoryView);
     await flushPromises();
 
     const translatedText = wrapper.find('.ti-m-target-preview');
     expect(translatedText.exists()).toBe(true);
-    expect(translatedText.text()).toBe('### سلام [salām]');
-    expect(translatedText.find('strong').exists()).toBe(false);
-    expect(translatedText.find('em').exists()).toBe(false);
-    expect(translatedText.html()).not.toContain('<strong>');
-    expect(translatedText.html()).not.toContain('<em>');
+    expect(translatedText.html()).not.toContain('onerror');
+    expect(translatedText.html()).not.toContain('alert(1)');
+    expect(translatedText.find('img').exists()).toBe(true);
+    expect(translatedText.element.querySelector('img')?.getAttribute('onerror')).toBeNull();
   });
 });

--- a/src/apps/content/components/mobile/views/HistoryView.test.js
+++ b/src/apps/content/components/mobile/views/HistoryView.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
+import HistoryView from './HistoryView.vue';
+
+const vajehyabMarkdown = '### سلام [salām]\n*اسم*\n\n---\n\n**معنی**:\nدرود';
+
+const mockHistory = {
+  historyItems: ref([
+    {
+      sourceText: 'source text',
+      translatedText: vajehyabMarkdown,
+      sourceLanguage: 'fa',
+      targetLanguage: 'en',
+      timestamp: 0,
+      mode: 'dictionary',
+    },
+  ]),
+  isLoading: ref(false),
+  hasHistory: ref(true),
+  loadHistory: vi.fn().mockResolvedValue(undefined),
+  deleteHistoryItem: vi.fn().mockResolvedValue(undefined),
+  clearAllHistory: vi.fn().mockResolvedValue(true),
+  exportHistory: vi.fn(),
+  formatTime: vi.fn(() => 'Just now'),
+};
+
+vi.mock('@/features/history/composables/useHistory.js', () => ({
+  useHistory: () => mockHistory,
+}));
+
+vi.mock('@/store/modules/mobile.js', () => ({
+  useMobileStore: () => ({
+    navigate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/settings/stores/settings.js', () => ({
+  useSettingsStore: () => ({
+    isDarkTheme: false,
+  }),
+}));
+
+vi.mock('@/composables/shared/useUnifiedI18n.js', () => ({
+  useUnifiedI18n: () => ({
+    t: (key, fallback) => fallback || key,
+  }),
+}));
+
+vi.mock('@/composables/shared/useLanguages.js', () => ({
+  useLanguages: () => ({
+    loadLanguages: vi.fn().mockResolvedValue(undefined),
+    getLanguageName: vi.fn((code) => code),
+  }),
+}));
+
+vi.mock('@/shared/utils/text/textAnalysis.js', () => ({
+  shouldApplyRtl: vi.fn(() => false),
+}));
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('HistoryView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('displays translated text as plain truncated text, not rich HTML', async () => {
+    const wrapper = mount(HistoryView);
+    await flushPromises();
+
+    const translatedText = wrapper.find('.ti-m-target-preview');
+    expect(translatedText.exists()).toBe(true);
+    expect(translatedText.text()).toBe('### سلام [salām]');
+    expect(translatedText.find('strong').exists()).toBe(false);
+    expect(translatedText.find('em').exists()).toBe(false);
+    expect(translatedText.html()).not.toContain('<strong>');
+    expect(translatedText.html()).not.toContain('<em>');
+  });
+});

--- a/src/apps/content/components/mobile/views/HistoryView.test.js
+++ b/src/apps/content/components/mobile/views/HistoryView.test.js
@@ -4,6 +4,14 @@ import { ref } from 'vue';
 import HistoryView from './HistoryView.vue';
 
 const vajehyabMarkdown = '### سلام [salām]\n*اسم*\n\n---\n\n**معنی**:\nدرود';
+const pronunciationMarkdown = [
+  '表达方式',
+  '',
+  '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+  '',
+  '- **名词**: 表达方式, 词语, 表情, 算式',
+  '- **同义词**: 词汇, 措辞, 呈现',
+].join('\n');
 
 const mockHistory = {
   historyItems: ref([
@@ -95,6 +103,22 @@ describe('HistoryView', () => {
     expect(translatedText.find('em').exists()).toBe(true);
     expect(translatedText.html()).toContain('<strong>معنی</strong>');
     expect(translatedText.html()).not.toContain('###');
+  });
+
+  it('keeps the pronunciation line inline with bold labels and IPA code in history previews', async () => {
+    mockHistory.historyItems.value[0].translatedText = pronunciationMarkdown;
+
+    const wrapper = mount(HistoryView);
+    await flushPromises();
+
+    const preview = wrapper.find('.ti-m-target-preview .simple-markdown');
+    const paragraphs = preview.findAll('p');
+
+    expect(preview.exists()).toBe(true);
+    expect(paragraphs[1].text().replace(/\s+/g, ' ')).toContain('UK : /ɪkˈspreʃnz/ US : /ɪkˈspreʃnz/');
+    expect(paragraphs[1].findAll('strong')).toHaveLength(2);
+    expect(paragraphs[1].findAll('code')).toHaveLength(2);
+    expect(paragraphs[1].html()).toContain('<code>/ɪkˈspreʃnz/</code>');
   });
 
   it('sanitizes unsafe markdown/html in translated text previews', async () => {

--- a/src/apps/content/components/mobile/views/HistoryView.vue
+++ b/src/apps/content/components/mobile/views/HistoryView.vue
@@ -107,7 +107,7 @@
         class="ti-m-history-list-inner"
       >
         <div 
-          v-for="(item, index) in historyItems" 
+          v-for="(item, index) in previewHistoryItems" 
           :key="item.timestamp || index"
           class="ti-m-history-card"
           @click="selectItem(item)"
@@ -138,9 +138,8 @@
           <div 
             class="ti-m-target-preview" 
             :dir="shouldApplyRtl(item.translatedText) ? 'rtl' : 'ltr'"
-          >
-            {{ truncateText(item.translatedText) }}
-          </div>
+            v-html="item.translatedPreviewHtml"
+          />
           
           <div class="ti-m-timestamp">
             {{ formatTime(item.timestamp) }}
@@ -153,12 +152,13 @@
 
 <script setup>
 import './HistoryView.scss'
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
 import { useMobileStore } from '@/store/modules/mobile.js'
 import { useSettingsStore } from '@/features/settings/stores/settings.js'
 import { useHistory } from '@/features/history/composables/useHistory.js'
 import { useLanguages } from '@/composables/shared/useLanguages.js'
+import { renderMarkdownPreview } from '@/shared/utils/text/markdownPreview.js'
 import { MOBILE_CONSTANTS } from '@/shared/constants/mobile.js'
 import { shouldApplyRtl } from "@/shared/utils/text/textAnalysis.js";
 import { getScopedLogger } from '@/shared/logging/logger.js'
@@ -179,6 +179,24 @@ const {
   exportHistory,
   formatTime
 } = useHistory()
+
+const previewHistoryItems = computed(() => {
+  return historyItems.value.map((item) => {
+    const rawSourceText = item.sourceText || ''
+    const rawTranslatedText = item.translatedText || ''
+
+    return {
+      ...item,
+      sourceText: rawSourceText,
+      translatedText: rawTranslatedText,
+      translatedPreviewHtml: renderMarkdownPreview(rawTranslatedText, {
+        fallbackDir: shouldApplyRtl(rawTranslatedText) ? 'rtl' : 'ltr',
+        isDictionary: String(item.mode || '').toLowerCase().includes('dictionary'),
+        enableMarkdown: true,
+      }),
+    }
+  })
+})
 
 onMounted(async () => {
   await languages.loadLanguages()

--- a/src/apps/content/components/mobile/views/HistoryView.vue
+++ b/src/apps/content/components/mobile/views/HistoryView.vue
@@ -135,11 +135,14 @@
           >
             {{ item.sourceText }}
           </div>
+          <!-- Sanitized HTML is produced by renderMarkdownPreview(). -->
+          <!-- eslint-disable vue/no-v-html -->
           <div 
             class="ti-m-target-preview" 
             :dir="shouldApplyRtl(item.translatedText) ? 'rtl' : 'ltr'"
             v-html="item.translatedPreviewHtml"
           />
+          <!-- eslint-enable vue/no-v-html -->
           
           <div class="ti-m-timestamp">
             {{ formatTime(item.timestamp) }}
@@ -202,20 +205,6 @@ onMounted(async () => {
   await languages.loadLanguages()
   await loadHistory(true)
 })
-
-// Truncate long text for display and handle dictionary results
-const truncateText = (text, maxLength = 200) => {
-  if (!text) return ''
-  
-  if (text.includes('\n**')) {
-    const firstLine = text.split('\n')[0].trim()
-    if (firstLine) {
-      return firstLine.length > maxLength ? firstLine.substring(0, maxLength) + '...' : firstLine
-    }
-  }
-  
-  return text.length > maxLength ? text.substring(0, maxLength) + '...' : text
-}
 
 const getLangName = (code) => {
   return languages.getLanguageName(code) || code

--- a/src/apps/content/components/mobile/views/HistoryView.vue
+++ b/src/apps/content/components/mobile/views/HistoryView.vue
@@ -135,14 +135,11 @@
           >
             {{ item.sourceText }}
           </div>
-          <!-- Sanitized HTML is produced by renderMarkdownPreview(). -->
-          <!-- eslint-disable vue/no-v-html -->
-          <div 
+          <SafeMarkdownPreview
             class="ti-m-target-preview" 
             :dir="shouldApplyRtl(item.translatedText) ? 'rtl' : 'ltr'"
-            v-html="item.translatedPreviewHtml"
+            :html="item.translatedPreviewHtml"
           />
-          <!-- eslint-enable vue/no-v-html -->
           
           <div class="ti-m-timestamp">
             {{ formatTime(item.timestamp) }}
@@ -162,6 +159,7 @@ import { useSettingsStore } from '@/features/settings/stores/settings.js'
 import { useHistory } from '@/features/history/composables/useHistory.js'
 import { useLanguages } from '@/composables/shared/useLanguages.js'
 import { renderMarkdownPreview } from '@/shared/utils/text/markdownPreview.js'
+import SafeMarkdownPreview from '@/components/shared/SafeMarkdownPreview.vue'
 import { MOBILE_CONSTANTS } from '@/shared/constants/mobile.js'
 import { shouldApplyRtl } from "@/shared/utils/text/textAnalysis.js";
 import { getScopedLogger } from '@/shared/logging/logger.js'

--- a/src/apps/sidepanel/components/SidepanelHistory.test.js
+++ b/src/apps/sidepanel/components/SidepanelHistory.test.js
@@ -32,7 +32,6 @@ const mockHistory = {
   clearAllHistory: vi.fn().mockResolvedValue(true),
   exportHistory: vi.fn(),
   formatTime: vi.fn(() => 'Just now'),
-  createMarkdownContent: vi.fn(() => '<div class="simple-markdown"><p>ignored</p></div>'),
 };
 
 vi.mock('@/features/history/composables/useHistory.js', () => ({
@@ -97,9 +96,48 @@ vi.mock('@/shared/logging/logger.js', () => ({
 describe('SidepanelHistory', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHistory.historyItems.value = [
+      {
+        sourceText: 'source text',
+        translatedText: googleMarkdown,
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        timestamp: 0,
+      },
+    ];
+    mockHistory.sortedHistoryItems.value = [
+      {
+        sourceText: 'source text',
+        translatedText: googleMarkdown,
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        timestamp: 0,
+      },
+    ];
   });
 
-  it('displays translated text as plain truncated text, not rich HTML', async () => {
+  it('renders translated text as sanitized markdown preview while keeping source text plain', async () => {
+    const wrapper = mount(SidepanelHistory, {
+      props: {
+        isVisible: true,
+      },
+    });
+
+    await flushPromises();
+
+    const translatedText = wrapper.find('.translated-text');
+    const sourceText = wrapper.find('.source-text');
+    expect(translatedText.exists()).toBe(true);
+    expect(sourceText.text()).toBe('source text');
+    expect(translatedText.find('strong').exists()).toBe(true);
+    expect(translatedText.html()).toContain('<strong>Noun</strong>');
+    expect(translatedText.html()).not.toContain('**Noun**');
+  });
+
+  it('sanitizes unsafe markdown/html in translated text previews', async () => {
+    mockHistory.historyItems.value[0].translatedText = '<img src=x onerror=alert(1)>';
+    mockHistory.sortedHistoryItems.value[0].translatedText = '<img src=x onerror=alert(1)>';
+
     const wrapper = mount(SidepanelHistory, {
       props: {
         isVisible: true,
@@ -110,10 +148,9 @@ describe('SidepanelHistory', () => {
 
     const translatedText = wrapper.find('.translated-text');
     expect(translatedText.exists()).toBe(true);
-    expect(translatedText.text()).toBe(googleMarkdown);
-    expect(translatedText.find('strong').exists()).toBe(false);
-    expect(translatedText.find('em').exists()).toBe(false);
-    expect(translatedText.html()).not.toContain('<strong>');
-    expect(translatedText.html()).not.toContain('<em>');
+    expect(translatedText.html()).not.toContain('onerror');
+    expect(translatedText.html()).not.toContain('alert(1)');
+    expect(translatedText.find('img').exists()).toBe(true);
+    expect(translatedText.element.querySelector('img')?.getAttribute('onerror')).toBeNull();
   });
 });

--- a/src/apps/sidepanel/components/SidepanelHistory.test.js
+++ b/src/apps/sidepanel/components/SidepanelHistory.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
+import SidepanelHistory from './SidepanelHistory.vue';
+
+const googleMarkdown = '**Noun**: test, experiment';
+
+const mockHistory = {
+  historyItems: ref([
+    {
+      sourceText: 'source text',
+      translatedText: googleMarkdown,
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      timestamp: 0,
+    },
+  ]),
+  sortedHistoryItems: ref([
+    {
+      sourceText: 'source text',
+      translatedText: googleMarkdown,
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      timestamp: 0,
+    },
+  ]),
+  hasHistory: ref(true),
+  isLoading: ref(false),
+  historyError: ref(''),
+  loadHistory: vi.fn().mockResolvedValue(undefined),
+  deleteHistoryItem: vi.fn().mockResolvedValue(undefined),
+  clearAllHistory: vi.fn().mockResolvedValue(true),
+  exportHistory: vi.fn(),
+  formatTime: vi.fn(() => 'Just now'),
+  createMarkdownContent: vi.fn(() => '<div class="simple-markdown"><p>ignored</p></div>'),
+};
+
+vi.mock('@/features/history/composables/useHistory.js', () => ({
+  useHistory: () => mockHistory,
+}));
+
+vi.mock('@/composables/ui/useUI.js', () => ({
+  useUI: () => ({
+    showVisualFeedback: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/shared/useErrorHandler.js', () => ({
+  useErrorHandler: () => ({
+    handleError: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/shared/useUnifiedI18n.js', () => ({
+  useUnifiedI18n: () => ({
+    t: (key, fallback) => fallback || key,
+  }),
+}));
+
+vi.mock('@/composables/shared/useLanguages.js', () => ({
+  useLanguages: () => ({
+    loadLanguages: vi.fn().mockResolvedValue(undefined),
+    getLanguageName: vi.fn((code) => code),
+  }),
+}));
+
+vi.mock('@/shared/utils/text/textAnalysis.js', () => ({
+  shouldApplyRtl: vi.fn(() => false),
+}));
+
+vi.mock('@/components/base/BaseDropdown.vue', () => ({
+  default: {
+    name: 'BaseDropdown',
+    setup() {
+      const toggle = vi.fn();
+      const close = vi.fn();
+      return { toggle, close };
+    },
+    template: `
+      <div class="base-dropdown-stub">
+        <slot name="trigger" :toggle="toggle" />
+        <slot :close="close" />
+      </div>
+    `,
+  },
+}));
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('SidepanelHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('displays translated text as plain truncated text, not rich HTML', async () => {
+    const wrapper = mount(SidepanelHistory, {
+      props: {
+        isVisible: true,
+      },
+    });
+
+    await flushPromises();
+
+    const translatedText = wrapper.find('.translated-text');
+    expect(translatedText.exists()).toBe(true);
+    expect(translatedText.text()).toBe(googleMarkdown);
+    expect(translatedText.find('strong').exists()).toBe(false);
+    expect(translatedText.find('em').exists()).toBe(false);
+    expect(translatedText.html()).not.toContain('<strong>');
+    expect(translatedText.html()).not.toContain('<em>');
+  });
+});

--- a/src/apps/sidepanel/components/SidepanelHistory.test.js
+++ b/src/apps/sidepanel/components/SidepanelHistory.test.js
@@ -4,6 +4,14 @@ import { ref } from 'vue';
 import SidepanelHistory from './SidepanelHistory.vue';
 
 const googleMarkdown = '**Noun**: test, experiment';
+const pronunciationMarkdown = [
+  'Expression',
+  '',
+  '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+  '',
+  '- **Noun**: Expression, phrase, wording',
+  '- **Synonyms**: Phrase, wording, statement',
+].join('\n');
 
 const mockHistory = {
   historyItems: ref([
@@ -132,6 +140,28 @@ describe('SidepanelHistory', () => {
     expect(translatedText.find('strong').exists()).toBe(true);
     expect(translatedText.html()).toContain('<strong>Noun</strong>');
     expect(translatedText.html()).not.toContain('**Noun**');
+  });
+
+  it('keeps the pronunciation line inline with bold labels and IPA code in history previews', async () => {
+    mockHistory.historyItems.value[0].translatedText = pronunciationMarkdown;
+    mockHistory.sortedHistoryItems.value[0].translatedText = pronunciationMarkdown;
+
+    const wrapper = mount(SidepanelHistory, {
+      props: {
+        isVisible: true,
+      },
+    });
+
+    await flushPromises();
+
+    const preview = wrapper.find('.translated-text .simple-markdown');
+    const paragraphs = preview.findAll('p');
+
+    expect(preview.exists()).toBe(true);
+    expect(paragraphs[1].text().replace(/\s+/g, ' ')).toContain('UK : /ɪkˈspreʃnz/ US : /ɪkˈspreʃnz/');
+    expect(paragraphs[1].findAll('strong')).toHaveLength(2);
+    expect(paragraphs[1].findAll('code')).toHaveLength(2);
+    expect(paragraphs[1].html()).toContain('<code>/ɪkˈspreʃnz/</code>');
   });
 
   it('sanitizes unsafe markdown/html in translated text previews', async () => {

--- a/src/apps/sidepanel/components/SidepanelHistory.vue
+++ b/src/apps/sidepanel/components/SidepanelHistory.vue
@@ -71,11 +71,14 @@
             <div class="arrow">
               ↓
             </div>
+            <!-- Sanitized HTML is produced by renderMarkdownPreview(). -->
+            <!-- eslint-disable vue/no-v-html -->
             <div 
               class="translated-text"
               :dir="shouldApplyRtl(item.translatedText) ? 'rtl' : 'ltr'"
               v-html="item.translatedPreviewHtml"
             />
+            <!-- eslint-enable vue/no-v-html -->
           </div>
         </div>
       </template>

--- a/src/apps/sidepanel/components/SidepanelHistory.vue
+++ b/src/apps/sidepanel/components/SidepanelHistory.vue
@@ -74,9 +74,8 @@
             <div 
               class="translated-text"
               :dir="shouldApplyRtl(item.translatedText) ? 'rtl' : 'ltr'"
-            >
-              {{ truncateText(item.translatedText) || '[No translation]' }}
-            </div>
+              v-html="item.translatedPreviewHtml"
+            />
           </div>
         </div>
       </template>
@@ -160,6 +159,7 @@ import { useErrorHandler } from '@/composables/shared/useErrorHandler.js'
 import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
 import { useLanguages } from '@/composables/shared/useLanguages.js'
 import { shouldApplyRtl } from "@/shared/utils/text/textAnalysis.js";
+import { renderMarkdownPreview } from "@/shared/utils/text/markdownPreview.js";
 import BaseDropdown from '@/components/base/BaseDropdown.vue'
 import { getScopedLogger } from '@/shared/logging/logger.js';
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';
@@ -236,7 +236,6 @@ const {
   clearAllHistory,
   exportHistory,
   formatTime,
-  createMarkdownContent,
   loadHistory
 } = useHistory()
 
@@ -263,7 +262,11 @@ const formattedHistoryItems = computed(() => {
       formattedTime: formatTime(item.timestamp),
       sourceLanguageName: languages.getLanguageName(item.sourceLanguage) || item.sourceLanguage,
       targetLanguageName: languages.getLanguageName(item.targetLanguage) || item.targetLanguage,
-      markdownContent: createMarkdownContent(processedTranslatedText),
+      translatedPreviewHtml: renderMarkdownPreview(processedTranslatedText, {
+        fallbackDir: shouldApplyRtl(processedTranslatedText) ? 'rtl' : 'ltr',
+        isDictionary: String(item.mode || '').toLowerCase().includes('dictionary'),
+        enableMarkdown: true,
+      }),
       // Ensure we have normalized field names
       sourceText: processedSourceText,
       translatedText: processedTranslatedText

--- a/src/apps/sidepanel/components/SidepanelHistory.vue
+++ b/src/apps/sidepanel/components/SidepanelHistory.vue
@@ -71,14 +71,11 @@
             <div class="arrow">
               ↓
             </div>
-            <!-- Sanitized HTML is produced by renderMarkdownPreview(). -->
-            <!-- eslint-disable vue/no-v-html -->
-            <div 
+            <SafeMarkdownPreview
               class="translated-text"
               :dir="shouldApplyRtl(item.translatedText) ? 'rtl' : 'ltr'"
-              v-html="item.translatedPreviewHtml"
+              :html="item.translatedPreviewHtml"
             />
-            <!-- eslint-enable vue/no-v-html -->
           </div>
         </div>
       </template>
@@ -163,6 +160,7 @@ import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
 import { useLanguages } from '@/composables/shared/useLanguages.js'
 import { shouldApplyRtl } from "@/shared/utils/text/textAnalysis.js";
 import { renderMarkdownPreview } from "@/shared/utils/text/markdownPreview.js";
+import SafeMarkdownPreview from '@/components/shared/SafeMarkdownPreview.vue'
 import BaseDropdown from '@/components/base/BaseDropdown.vue'
 import { getScopedLogger } from '@/shared/logging/logger.js';
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';

--- a/src/components/shared/SafeMarkdownPreview.vue
+++ b/src/components/shared/SafeMarkdownPreview.vue
@@ -1,0 +1,27 @@
+<!-- eslint-disable vue/no-v-html -->
+<template>
+  <div
+    class="safe-markdown-preview"
+    v-bind="$attrs"
+    :dir="props.dir"
+    v-html="props.html"
+  />
+</template>
+
+<script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
+// Trusted HTML must be produced by renderMarkdownPreview() before being passed here.
+const props = defineProps({
+  html: {
+    type: String,
+    default: "",
+  },
+  dir: {
+    type: String,
+    default: undefined,
+  },
+});
+</script>

--- a/src/components/shared/TranslationDisplay.scss
+++ b/src/components/shared/TranslationDisplay.scss
@@ -262,22 +262,33 @@
     }
 
     .md-label-list-group {
-      margin: 0 0 2px 0 !important;
+      margin: 0 0 4px 0 !important;
     }
 
     .md-label-list-group > p.md-label-paragraph {
-      margin-bottom: 0 !important;
+      margin: 0 0 1px 0 !important;
+      line-height: 1.25 !important;
     }
 
     .md-label-list-group > ul.md-label-list,
     .md-label-list-group > ol.md-label-list {
-      margin: 0 !important;
+      list-style-position: outside !important;
+      list-style-type: initial !important;
+      padding-block-start: 0 !important;
+      padding-block-end: 0 !important;
       padding-inline-start: 1.15em !important;
+      margin: 0 !important;
+    }
+
+    .md-label-list-group > ol.md-label-list {
+      list-style-type: decimal !important;
     }
 
     .md-label-list-group > ul.md-label-list > li,
     .md-label-list-group > ol.md-label-list > li {
-      margin-block: 0.1em !important;
+      display: list-item !important;
+      margin-block: 0.08em !important;
+      line-height: 1.35 !important;
     }
 
     code {

--- a/src/components/shared/TranslationDisplay.scss
+++ b/src/components/shared/TranslationDisplay.scss
@@ -292,7 +292,7 @@
     }
 
     code {
-      background: var(--bg-secondary, #f8f9fa) !important;
+      background-color: var(--color-code-inline-bg, rgb(0 0 0 / 10%)) !important;
       padding: 2px 4px !important;
       border-radius: 3px !important;
       font-family: "Courier New", monospace !important;
@@ -300,7 +300,7 @@
     }
 
     pre {
-      background: var(--bg-secondary, #f8f9fa) !important;
+      background-color: var(--color-code-block-bg, rgb(0 0 0 / 5%)) !important;
       padding: 12px !important;
       border-radius: 4px !important;
       overflow-x: auto !important;

--- a/src/components/shared/TranslationDisplay.scss
+++ b/src/components/shared/TranslationDisplay.scss
@@ -231,7 +231,7 @@
     ul, ol {
       list-style-position: outside !important;
       padding-inline-start: 1.25em !important;
-      margin-block: 6px !important;
+      margin-block: 0 3px !important;
       margin-inline: 0 !important;
     }
 
@@ -257,8 +257,27 @@
     h3 { font-size: 15px !important; }
 
     p { 
-      margin-bottom: 8px !important; 
+      margin-bottom: 2px !important; 
       &:last-child { margin-bottom: 0 !important; }
+    }
+
+    .md-label-list-group {
+      margin: 0 0 2px 0 !important;
+    }
+
+    .md-label-list-group > p.md-label-paragraph {
+      margin-bottom: 0 !important;
+    }
+
+    .md-label-list-group > ul.md-label-list,
+    .md-label-list-group > ol.md-label-list {
+      margin: 0 !important;
+      padding-inline-start: 1.15em !important;
+    }
+
+    .md-label-list-group > ul.md-label-list > li,
+    .md-label-list-group > ol.md-label-list > li {
+      margin-block: 0.1em !important;
     }
 
     code {

--- a/src/components/shared/TranslationDisplay.scss
+++ b/src/components/shared/TranslationDisplay.scss
@@ -229,47 +229,21 @@
   // Markdown Elements
   .simple-markdown {
     ul, ol {
-      list-style: none !important;
-      padding: 0 !important;
-      margin: 6px 0 !important;
-      display: flex !important;
-      flex-direction: column !important;
-      gap: 4px !important;
+      list-style-position: outside !important;
+      padding-inline-start: 1.25em !important;
+      margin-block: 6px !important;
+      margin-inline: 0 !important;
     }
 
     li {
-      display: grid !important;
-      grid-template-columns: auto 1fr !important;
-      align-items: start !important;
-      gap: 0.5em !important;
+      display: list-item !important;
       line-height: 1.4 !important;
-      margin: 0 !important;
-      min-height: 1.2em !important;
-
-      &::before {
-        grid-column: 1 !important;
-        text-align: left !important;
-      }
-
-      & > * {
-        grid-column: 2 !important;
-      }
-    }
-
-    ul > li::before {
-      content: "•" !important;
-      font-weight: bold !important;
+      margin-block: 0.15em !important;
+      margin-inline: 0 !important;
     }
 
     ol {
-      counter-reset: list-counter !important;
-      & > li {
-        counter-increment: list-counter !important;
-        &::before {
-          content: counter(list-counter) "." !important;
-          min-width: 1.5em !important;
-        }
-      }
+      list-style-type: decimal !important;
     }
 
     h1, h2, h3 {
@@ -490,11 +464,6 @@
 
     &.has-error {
       text-align: center !important;
-    }
-
-    .simple-markdown {
-      li::before { text-align: right !important; }
-      ol > li::before { text-align: right !important; }
     }
   }
 

--- a/src/components/shared/TranslationDisplay.test.js
+++ b/src/components/shared/TranslationDisplay.test.js
@@ -6,10 +6,16 @@ import { SimpleMarkdown } from '@/shared/utils/text/markdown.js';
 import { TranslationMode } from '@/shared/config/config.js';
 
 vi.mock('@/composables/shared/useTextDirection.js', () => ({
-  useTextDirection: () => ({
-    direction: ref('ltr'),
-    textAlign: ref('left'),
-  }),
+  useTextDirection: (contentRef) => {
+    const text = typeof contentRef?.value === 'string' ? contentRef.value : '';
+    const rtlCount = (text.match(/[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/g) || []).length;
+    const direction = rtlCount > 0 ? 'rtl' : 'ltr';
+
+    return {
+      direction: ref(direction),
+      textAlign: ref(direction === 'rtl' ? 'right' : 'left'),
+    };
+  },
 }));
 
 vi.mock('@/composables/shared/useFont.js', () => ({
@@ -67,7 +73,7 @@ describe('TranslationDisplay.vue', () => {
   it('renders normalized Google bold-label markdown through the modern marked path', async () => {
     const renderSpy = vi.spyOn(SimpleMarkdown, 'render');
     const wrapper = await mountDisplay({
-      content: '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test',
+      content: 'بله\n\n**Pronunciation**: /yes/\n\n**Definitions**:\n- (علامت تعجب) used to give an affirmative response.\n\n**Examples**:\n- you think I perhaps killed Westbourne, yes?',
       lastTranslation: {
         mode: TranslationMode.Dictionary_Translation,
       },
@@ -76,9 +82,11 @@ describe('TranslationDisplay.vue', () => {
     expect(renderSpy).not.toHaveBeenCalled();
     const markdown = wrapper.find('.simple-markdown');
     expect(markdown.exists()).toBe(true);
-    expect(markdown.find('strong').text()).toBe('Noun');
-    expect(markdown.text()).toContain('Pronunciation');
-    expect(markdown.find('a').exists()).toBe(false);
+    const directParagraphs = Array.from(markdown.element.children).filter((el) => el.tagName === 'P');
+    expect(directParagraphs[0].getAttribute('dir')).toBe('rtl');
+    expect(directParagraphs[1].getAttribute('dir')).toBe('ltr');
+    expect(markdown.find('p.md-label-paragraph').attributes('dir')).toBe('ltr');
+    expect(markdown.find('ul.md-label-list > li').attributes('dir')).toBe('ltr');
   });
 
   it('renders Vajehyab markdown-like output through the modern marked path', async () => {
@@ -96,11 +104,13 @@ describe('TranslationDisplay.vue', () => {
     expect(markdown.find('h3').text()).toBe('سلام [salām]');
     expect(markdown.find('em').text()).toBe('اسم');
     expect(markdown.find('strong').text()).toBe('معنی (لغت‌نامه عمید)');
+    expect(markdown.find('h3').attributes('dir')).toBe('rtl');
+    expect(markdown.find('strong').element.parentElement?.getAttribute('dir')).toBe('rtl');
   });
 
   it('marks label paragraphs followed by lists for tighter spacing', async () => {
     const wrapper = await mountDisplay({
-      content: '**Definitions**:\n- item',
+      content: 'بله\n\n**Pronunciation**: /yes/\n\n**Definitions**:\n- (علامت تعجب) used to give an affirmative response.',
       lastTranslation: {
         mode: TranslationMode.Dictionary_Translation,
       },
@@ -114,8 +124,11 @@ describe('TranslationDisplay.vue', () => {
     expect(paragraph.exists()).toBe(true);
     expect(paragraph.text()).toBe('Definitions:');
     expect(list.exists()).toBe(true);
-    expect(list.text()).toBe('item');
+    expect(list.text()).toContain('used to give an affirmative response.');
     expect(list.element.firstChild?.nodeType).toBe(Node.ELEMENT_NODE);
+    expect(paragraph.attributes('dir')).toBe('ltr');
+    expect(list.attributes('dir')).toBe('ltr');
+    expect(list.find('li').attributes('dir')).toBe('ltr');
   });
 
   it('does not add label spacing classes for ordinary paragraph/list content', async () => {

--- a/src/components/shared/TranslationDisplay.test.js
+++ b/src/components/shared/TranslationDisplay.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import TranslationDisplay from './TranslationDisplay.vue';
 import { SimpleMarkdown } from '@/shared/utils/text/markdown.js';
 import { TranslationMode } from '@/shared/config/config.js';
@@ -51,61 +51,172 @@ describe('TranslationDisplay.vue', () => {
     vi.clearAllMocks();
   });
 
-  it('enables dictionary label formatting when lastTranslation.mode is dictionary', async () => {
-    const renderSpy = vi
-      .spyOn(SimpleMarkdown, 'render')
-      .mockImplementation(() => {
-        const el = document.createElement('div');
-        el.className = 'simple-markdown';
-        return el;
-      });
-
-    mount(TranslationDisplay, {
+  const mountDisplay = async (props) => {
+    const wrapper = mount(TranslationDisplay, {
       props: {
-        content: '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
-        mode: 'compact',
-        lastTranslation: {
-          mode: TranslationMode.Dictionary_Translation,
-        },
         showToolbar: false,
         enableMarkdown: true,
+        ...props,
       },
     });
 
-    expect(renderSpy).toHaveBeenCalledWith(
-      '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
-      'ltr',
-      expect.objectContaining({
-        enableLabelFormatting: true,
-      }),
-    );
+    await nextTick();
+    return wrapper;
+  };
+
+  it('renders normalized Google bold-label markdown through the modern marked path', async () => {
+    const renderSpy = vi.spyOn(SimpleMarkdown, 'render');
+    const wrapper = await mountDisplay({
+      content: '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test',
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
+      },
+    });
+
+    expect(renderSpy).not.toHaveBeenCalled();
+    const markdown = wrapper.find('.simple-markdown');
+    expect(markdown.exists()).toBe(true);
+    expect(markdown.find('strong').text()).toBe('Noun');
+    expect(markdown.text()).toContain('Pronunciation');
+    expect(markdown.find('a').exists()).toBe(false);
   });
 
-  it('keeps label formatting disabled for non-dictionary compact content', async () => {
+  it('renders Vajehyab markdown-like output through the modern marked path', async () => {
+    const renderSpy = vi.spyOn(SimpleMarkdown, 'render');
+    const wrapper = await mountDisplay({
+      content: '### سلام [salām]\n*اسم*\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nدرود، تحیت',
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
+      },
+    });
+
+    expect(renderSpy).not.toHaveBeenCalled();
+    const markdown = wrapper.find('.simple-markdown');
+    expect(markdown.exists()).toBe(true);
+    expect(markdown.find('h3').text()).toBe('سلام [salām]');
+    expect(markdown.find('em').text()).toBe('اسم');
+    expect(markdown.find('strong').text()).toBe('معنی (لغت‌نامه عمید)');
+  });
+
+  it('falls back to SimpleMarkdown for legacy one-line concatenated output', async () => {
     const renderSpy = vi
       .spyOn(SimpleMarkdown, 'render')
       .mockImplementation(() => {
         const el = document.createElement('div');
         el.className = 'simple-markdown';
+        el.innerHTML = '<p>translation</p>';
         return el;
       });
 
-    mount(TranslationDisplay, {
-      props: {
-        content: '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
-        mode: 'compact',
-        lastTranslation: null,
-        showToolbar: false,
-        enableMarkdown: true,
+    const wrapper = await mountDisplay({
+      content: 'translation **Noun**: hello, hi',
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
       },
     });
 
-    expect(renderSpy).toHaveBeenCalledWith(
-      '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
-      'ltr',
-      expect.objectContaining({
-        enableLabelFormatting: false,
-      }),
-    );
+    expect(renderSpy).toHaveBeenCalled();
+    expect(wrapper.find('.simple-markdown').exists()).toBe(true);
+    expect(wrapper.find('.simple-markdown').text()).toBe('translation');
+  });
+
+  it('falls back to SimpleMarkdown for same-line multi-label legacy output', async () => {
+    const renderSpy = vi
+      .spyOn(SimpleMarkdown, 'render')
+      .mockImplementation(() => {
+        const el = document.createElement('div');
+        el.className = 'simple-markdown';
+        el.innerHTML = '<p>UK: hello US: hi</p>';
+        return el;
+      });
+
+    const wrapper = await mountDisplay({
+      content: '**UK**: hello **US**: hi',
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
+      },
+    });
+
+    expect(renderSpy).toHaveBeenCalled();
+    expect(wrapper.find('.simple-markdown').text()).toBe('UK: hello US: hi');
+  });
+
+  it('falls back to SimpleMarkdown for plain Label: content only in dictionary mode', async () => {
+    const renderSpy = vi
+      .spyOn(SimpleMarkdown, 'render')
+      .mockImplementation(() => {
+        const el = document.createElement('div');
+        el.className = 'simple-markdown';
+        el.innerHTML = '<p>Noun: test, experiment</p>';
+        return el;
+      });
+
+    const dictionaryWrapper = await mountDisplay({
+      content: 'Noun: test, experiment',
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
+      },
+    });
+
+    expect(renderSpy).toHaveBeenCalled();
+    expect(dictionaryWrapper.find('.simple-markdown').text()).toBe('Noun: test, experiment');
+
+    renderSpy.mockClear();
+
+    const normalWrapper = await mountDisplay({
+      content: 'Noun: test, experiment',
+      lastTranslation: null,
+    });
+
+    expect(renderSpy).not.toHaveBeenCalled();
+    expect(normalWrapper.find('.simple-markdown').exists()).toBe(true);
+    expect(normalWrapper.find('.simple-markdown').text()).toBe('Noun: test, experiment');
+  });
+
+  it('preserves the simple-markdown wrapper in the rendered HTML', async () => {
+    const wrapper = await mountDisplay({
+      content: '**Noun**: test, experiment',
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
+      },
+    });
+
+    expect(wrapper.find('.simple-markdown').exists()).toBe(true);
+  });
+
+  it('neutralizes unsafe links and removes their href', async () => {
+    const wrapper = await mountDisplay({
+      content: '[Click](javascript:alert(1))',
+      lastTranslation: null,
+    });
+
+    expect(wrapper.find('.simple-markdown').exists()).toBe(true);
+    expect(wrapper.find('a').exists()).toBe(false);
+    expect(wrapper.text()).toContain('Click');
+    expect(wrapper.html()).not.toContain('javascript:');
+  });
+
+  it('strips raw HTML XSS attributes from rendered content', async () => {
+    const wrapper = await mountDisplay({
+      content: '<img src=x onerror=alert(1)>',
+      lastTranslation: null,
+    });
+
+    expect(wrapper.html()).not.toContain('onerror');
+    expect(wrapper.html()).not.toContain('alert(1)');
+    expect(wrapper.element.querySelector('[onerror]')).toBeNull();
+  });
+
+  it('keeps safe links with target blank and noopener noreferrer', async () => {
+    const wrapper = await mountDisplay({
+      content: '[Click](https://example.com)',
+      lastTranslation: null,
+    });
+
+    const link = wrapper.find('a');
+    expect(link.exists()).toBe(true);
+    expect(link.attributes('href')).toBe('https://example.com');
+    expect(link.attributes('target')).toBe('_blank');
+    expect(link.attributes('rel')).toBe('noopener noreferrer');
   });
 });

--- a/src/components/shared/TranslationDisplay.test.js
+++ b/src/components/shared/TranslationDisplay.test.js
@@ -115,6 +115,7 @@ describe('TranslationDisplay.vue', () => {
     expect(paragraph.text()).toBe('Definitions:');
     expect(list.exists()).toBe(true);
     expect(list.text()).toBe('item');
+    expect(list.element.firstChild?.nodeType).toBe(Node.ELEMENT_NODE);
   });
 
   it('does not add label spacing classes for ordinary paragraph/list content', async () => {

--- a/src/components/shared/TranslationDisplay.test.js
+++ b/src/components/shared/TranslationDisplay.test.js
@@ -4,6 +4,14 @@ import { nextTick, ref } from 'vue';
 import TranslationDisplay from './TranslationDisplay.vue';
 import { SimpleMarkdown } from '@/shared/utils/text/markdown.js';
 import { TranslationMode } from '@/shared/config/config.js';
+const pronunciationMarkdown = [
+  'Expression',
+  '',
+  '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+  '',
+  '- **Noun**: Expression, phrase, wording',
+  '- **Synonyms**: Phrase, wording, statement',
+].join('\n');
 
 vi.mock('@/composables/shared/useTextDirection.js', () => ({
   useTextDirection: (contentRef) => {
@@ -87,6 +95,26 @@ describe('TranslationDisplay.vue', () => {
     expect(directParagraphs[1].getAttribute('dir')).toBe('ltr');
     expect(markdown.find('p.md-label-paragraph').attributes('dir')).toBe('ltr');
     expect(markdown.find('ul.md-label-list > li').attributes('dir')).toBe('ltr');
+  });
+
+  it('keeps pronunciation labels and IPA text on the same rendered line', async () => {
+    const wrapper = await mountDisplay({
+      content: pronunciationMarkdown,
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
+      },
+    });
+
+    const paragraphs = wrapper.findAll('.simple-markdown > p');
+    expect(paragraphs.length).toBeGreaterThanOrEqual(2);
+
+    const pronunciationLine = paragraphs[1];
+    expect(pronunciationLine.text().replace(/\s+/g, ' ')).toContain('UK : /ɪkˈspreʃnz/ US : /ɪkˈspreʃnz/');
+    expect(pronunciationLine.findAll('strong')).toHaveLength(2);
+    expect(pronunciationLine.findAll('code')).toHaveLength(2);
+    expect(pronunciationLine.html()).toContain('<code>/ɪkˈspreʃnz/</code>');
+    expect(pronunciationLine.html()).not.toContain('<br>');
+    expect(pronunciationLine.attributes('dir')).toBe('ltr');
   });
 
   it('renders Vajehyab markdown-like output through the modern marked path', async () => {

--- a/src/components/shared/TranslationDisplay.test.js
+++ b/src/components/shared/TranslationDisplay.test.js
@@ -98,6 +98,36 @@ describe('TranslationDisplay.vue', () => {
     expect(markdown.find('strong').text()).toBe('معنی (لغت‌نامه عمید)');
   });
 
+  it('marks label paragraphs followed by lists for tighter spacing', async () => {
+    const wrapper = await mountDisplay({
+      content: '**Definitions**:\n- item',
+      lastTranslation: {
+        mode: TranslationMode.Dictionary_Translation,
+      },
+    });
+
+    const group = wrapper.find('.md-label-list-group');
+    const paragraph = group.find('p.md-label-paragraph');
+    const list = group.find('ul.md-label-list');
+
+    expect(group.exists()).toBe(true);
+    expect(paragraph.exists()).toBe(true);
+    expect(paragraph.text()).toBe('Definitions:');
+    expect(list.exists()).toBe(true);
+    expect(list.text()).toBe('item');
+  });
+
+  it('does not add label spacing classes for ordinary paragraph/list content', async () => {
+    const wrapper = await mountDisplay({
+      content: 'Intro text\n\n- item',
+      lastTranslation: null,
+    });
+
+    expect(wrapper.find('.md-label-list-group').exists()).toBe(false);
+    expect(wrapper.find('p.md-label-paragraph').exists()).toBe(false);
+    expect(wrapper.find('ul.md-label-list').exists()).toBe(false);
+  });
+
   it('falls back to SimpleMarkdown for legacy one-line concatenated output', async () => {
     const renderSpy = vi
       .spyOn(SimpleMarkdown, 'render')

--- a/src/components/shared/TranslationDisplay.vue
+++ b/src/components/shared/TranslationDisplay.vue
@@ -394,6 +394,12 @@ const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false) => {
     paragraph.classList.add('md-label-paragraph');
     nextElement.classList.add('md-label-list');
 
+    Array.from(nextElement.childNodes).forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE && !node.textContent.trim()) {
+        node.remove();
+      }
+    });
+
     paragraph.parentNode.insertBefore(group, paragraph);
     group.appendChild(paragraph);
     group.appendChild(nextElement);

--- a/src/components/shared/TranslationDisplay.vue
+++ b/src/components/shared/TranslationDisplay.vue
@@ -174,12 +174,11 @@
 <script setup>
 import './TranslationDisplay.scss';
 import { ref, computed, watch, onMounted } from "vue";
-import { marked } from "marked";
 import { useSettingsStore } from "@/features/settings/stores/settings.js";
 import { useTextDirection } from "@/composables/shared/useTextDirection.js";
 import { SimpleMarkdown, ExtractionStrategy } from "@/shared/utils/text/markdown.js";
 import { TranslationMode } from "@/shared/config/config.js";
-import DOMPurify from "dompurify";
+import { renderMarkdownPreview } from "@/shared/utils/text/markdownPreview.js";
 import ActionToolbar from "@/features/text-actions/components/ActionToolbar.vue";
 import LoadingSpinner from "@/components/base/LoadingSpinner.vue";
 import { useFont } from "@/composables/shared/useFont.js";
@@ -351,200 +350,6 @@ const containerRef = ref(null);
 // Scoped logger
 const logger = getScopedLogger(LOG_COMPONENTS.UI, "TranslationDisplay");
 
-const LEGACY_PLAIN_LABEL_RE = /^[^:*#>`\-\s][^:]{0,80}:\s+\S+/;
-const RTL_CHAR_RE = /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/g;
-const NON_RTL_STRONG_CHAR_RE = /[a-zA-Z\u00C0-\u024F\u0370-\u03FF\u0400-\u04FF\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/g;
-
-const countMatches = (text, regex) => (text.match(regex) || []).length;
-
-const detectBlockDirection = (text, fallbackDir = 'ltr') => {
-  if (!text || typeof text !== 'string') {
-    return fallbackDir;
-  }
-
-  const normalized = text.replace(/\s+/g, ' ').trim();
-  if (!normalized) {
-    return fallbackDir;
-  }
-
-  const labelSeparatorIndex = normalized.indexOf(':');
-  const hasLabelShape = labelSeparatorIndex > -1 && !normalized.includes('://');
-  const candidateText = hasLabelShape
-    ? normalized.slice(labelSeparatorIndex + 1).trim() || normalized
-    : normalized;
-
-  const rtlCount = countMatches(candidateText, RTL_CHAR_RE);
-  const ltrCount = countMatches(candidateText, NON_RTL_STRONG_CHAR_RE);
-
-  if (rtlCount === 0 && ltrCount === 0) {
-    return fallbackDir;
-  }
-
-  if (hasLabelShape && candidateText !== normalized) {
-    if (ltrCount > rtlCount) return 'ltr';
-    if (rtlCount > ltrCount) return 'rtl';
-    return fallbackDir;
-  }
-
-  if (ltrCount === 0) return 'rtl';
-  if (rtlCount === 0) return 'ltr';
-
-  if (ltrCount > rtlCount && (ltrCount - rtlCount >= 2 || ltrCount >= rtlCount * 1.5)) {
-    return 'ltr';
-  }
-
-  if (rtlCount > ltrCount && (rtlCount - ltrCount >= 2 || rtlCount >= ltrCount * 1.5)) {
-    return 'rtl';
-  }
-
-  if (/^[\u0590-\u08FF]/.test(normalized)) {
-    return fallbackDir;
-  }
-
-  if (/^[A-Za-z\u00C0-\u024F]/.test(normalized)) {
-    return 'ltr';
-  }
-
-  return fallbackDir;
-};
-
-const applyBlockDirection = (element, fallbackDir) => {
-  if (!element || element.nodeType !== Node.ELEMENT_NODE) {
-    return;
-  }
-
-  const direction = detectBlockDirection(element.textContent || '', fallbackDir);
-  element.setAttribute('dir', direction);
-};
-
-const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false) => {
-  if (!html || typeof html !== 'string') {
-    return '';
-  }
-
-  const sanitizedHtml = DOMPurify.sanitize(html);
-  if (!sanitizedHtml) {
-    return '';
-  }
-
-  const container = document.createElement('div');
-  container.innerHTML = wrapWithSimpleMarkdown
-    ? `<div class="simple-markdown">${sanitizedHtml}</div>`
-    : sanitizedHtml;
-
-  const root = container.querySelector('.simple-markdown') || container.firstElementChild || container;
-
-  if (!root) {
-    return '';
-  }
-
-  // Wrap dictionary label paragraphs and their following lists so CSS can treat them
-  // as a compact unit without changing provider output or markdown shape.
-  root.querySelectorAll('p').forEach((paragraph) => {
-    const nextElement = paragraph.nextElementSibling;
-    const isLabelParagraph = (
-      paragraph.textContent?.trim().endsWith(':') &&
-      paragraph.querySelector('strong') &&
-      nextElement &&
-      ['UL', 'OL'].includes(nextElement.tagName)
-    );
-
-    if (!isLabelParagraph) {
-      return;
-    }
-
-    const group = document.createElement('div');
-    group.className = 'md-label-list-group';
-    paragraph.classList.add('md-label-paragraph');
-    nextElement.classList.add('md-label-list');
-
-    Array.from(nextElement.childNodes).forEach((node) => {
-      if (node.nodeType === Node.TEXT_NODE && !node.textContent.trim()) {
-        node.remove();
-      }
-    });
-
-    paragraph.parentNode.insertBefore(group, paragraph);
-    group.appendChild(paragraph);
-    group.appendChild(nextElement);
-  });
-
-  root
-    .querySelectorAll('p, h1, h2, h3, h4, h5, h6, blockquote, pre, ul, ol, li, .md-label-list-group, .md-label-paragraph, .md-label-list')
-    .forEach((element) => {
-      applyBlockDirection(element, textDirection.value.dir);
-    });
-
-  root.querySelectorAll('a').forEach((link) => {
-    const href = (link.getAttribute('href') || '').trim();
-
-    if (!/^https?:\/\//i.test(href)) {
-      const textNode = document.createTextNode(link.textContent || '');
-      link.replaceWith(textNode);
-      return;
-    }
-
-    link.setAttribute('target', '_blank');
-    link.setAttribute('rel', 'noopener noreferrer');
-  });
-
-  if (root.classList && !root.classList.contains('simple-markdown')) {
-    root.classList.add('simple-markdown');
-  }
-
-  return DOMPurify.sanitize(root.outerHTML, {
-    ADD_ATTR: ['target', 'rel'],
-  });
-};
-
-const shouldUseLegacySimpleMarkdown = (content, isDictionary) => {
-  if (!content || typeof content !== 'string') {
-    return false;
-  }
-
-  const normalized = content.trim();
-  if (!normalized) {
-    return false;
-  }
-
-  const lines = normalized.split('\n').map((line) => line.trim()).filter(Boolean);
-  if (lines.length === 0) {
-    return false;
-  }
-
-  if (lines.length === 1) {
-    const line = lines[0];
-
-    // Legacy one-line concatenated provider output:
-    // "translation **Noun**: hello, hi"
-    const oneLineLabelMatch = line.match(/^(.*?)\*\*.*?\*\*.*:(?!\/\/)/);
-    if (oneLineLabelMatch && oneLineLabelMatch[1].trim().length > 0) {
-      return true;
-    }
-
-    // Same-line multi-label legacy dictionary output:
-    // "**UK**: hello **US**: hi"
-    const boldLabelMatches = line.match(/\*\*[^*]+?\*\*/g) || [];
-    if (boldLabelMatches.length > 1 && line.includes(':')) {
-      return true;
-    }
-
-    // Plain label content only falls back in dictionary mode.
-    if (isDictionary && !line.includes('**') && LEGACY_PLAIN_LABEL_RE.test(line)) {
-      return true;
-    }
-
-    return false;
-  }
-
-  // Multi-line plain label blocks are still legacy compatibility data.
-  if (isDictionary && !normalized.includes('**')) {
-    return lines.some((line) => LEGACY_PLAIN_LABEL_RE.test(line));
-  }
-
-  return false;
-};
-
 // Computed
 const hasContent = computed(
   () => (props.content && props.content.trim().length > 0 && !props.isLoading) || (props.isStreaming && props.content)
@@ -675,34 +480,11 @@ const renderedContent = computed(() => {
     return '';
   }
 
-  if (props.enableMarkdown) {
-    try {
-      if (shouldUseLegacySimpleMarkdown(props.content, isDictionary.value)) {
-        const markdownElement = SimpleMarkdown.render(props.content, textDirection.value.dir, {
-          enableLabelFormatting: isDictionary.value
-        });
-
-        if (markdownElement) {
-          return normalizeRenderedHtml(markdownElement.outerHTML, false);
-        }
-
-        return normalizeRenderedHtml(props.content.replace(/\n/g, "<br>"), true);
-      }
-
-      const markedHtml = marked.parse(props.content, {
-        gfm: true,
-        breaks: false,
-        mangle: false,
-      });
-
-      return normalizeRenderedHtml(markedHtml, true);
-    } catch (error) {
-      logger.warn("[TranslationDisplay] Markdown rendering failed:", error);
-      return normalizeRenderedHtml(props.content.replace(/\n/g, "<br>"), true);
-    }
-  } else {
-    return normalizeRenderedHtml(props.content.replace(/\n/g, "<br>"), true);
-  }
+  return renderMarkdownPreview(props.content, {
+    fallbackDir: textDirection.value.dir,
+    isDictionary: isDictionary.value,
+    enableMarkdown: props.enableMarkdown,
+  });
 });
 
 // Watchers

--- a/src/components/shared/TranslationDisplay.vue
+++ b/src/components/shared/TranslationDisplay.vue
@@ -174,6 +174,7 @@
 <script setup>
 import './TranslationDisplay.scss';
 import { ref, computed, watch, onMounted } from "vue";
+import { marked } from "marked";
 import { useSettingsStore } from "@/features/settings/stores/settings.js";
 import { useTextDirection } from "@/composables/shared/useTextDirection.js";
 import { SimpleMarkdown, ExtractionStrategy } from "@/shared/utils/text/markdown.js";
@@ -350,6 +351,99 @@ const containerRef = ref(null);
 // Scoped logger
 const logger = getScopedLogger(LOG_COMPONENTS.UI, "TranslationDisplay");
 
+const LEGACY_PLAIN_LABEL_RE = /^[^:*#>`\-\s][^:]{0,80}:\s+\S+/;
+
+const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false) => {
+  if (!html || typeof html !== 'string') {
+    return '';
+  }
+
+  const sanitizedHtml = DOMPurify.sanitize(html);
+  if (!sanitizedHtml) {
+    return '';
+  }
+
+  const container = document.createElement('div');
+  container.innerHTML = wrapWithSimpleMarkdown
+    ? `<div class="simple-markdown">${sanitizedHtml}</div>`
+    : sanitizedHtml;
+
+  const root = container.querySelector('.simple-markdown') || container.firstElementChild || container;
+
+  if (!root) {
+    return '';
+  }
+
+  root.querySelectorAll('a').forEach((link) => {
+    const href = (link.getAttribute('href') || '').trim();
+
+    if (!/^https?:\/\//i.test(href)) {
+      const textNode = document.createTextNode(link.textContent || '');
+      link.replaceWith(textNode);
+      return;
+    }
+
+    link.setAttribute('target', '_blank');
+    link.setAttribute('rel', 'noopener noreferrer');
+  });
+
+  if (root.classList && !root.classList.contains('simple-markdown')) {
+    root.classList.add('simple-markdown');
+  }
+
+  return DOMPurify.sanitize(root.outerHTML, {
+    ADD_ATTR: ['target', 'rel'],
+  });
+};
+
+const shouldUseLegacySimpleMarkdown = (content, isDictionary) => {
+  if (!content || typeof content !== 'string') {
+    return false;
+  }
+
+  const normalized = content.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  const lines = normalized.split('\n').map((line) => line.trim()).filter(Boolean);
+  if (lines.length === 0) {
+    return false;
+  }
+
+  if (lines.length === 1) {
+    const line = lines[0];
+
+    // Legacy one-line concatenated provider output:
+    // "translation **Noun**: hello, hi"
+    const oneLineLabelMatch = line.match(/^(.*?)\*\*.*?\*\*.*:(?!\/\/)/);
+    if (oneLineLabelMatch && oneLineLabelMatch[1].trim().length > 0) {
+      return true;
+    }
+
+    // Same-line multi-label legacy dictionary output:
+    // "**UK**: hello **US**: hi"
+    const boldLabelMatches = line.match(/\*\*[^*]+?\*\*/g) || [];
+    if (boldLabelMatches.length > 1 && line.includes(':')) {
+      return true;
+    }
+
+    // Plain label content only falls back in dictionary mode.
+    if (isDictionary && !line.includes('**') && LEGACY_PLAIN_LABEL_RE.test(line)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // Multi-line plain label blocks are still legacy compatibility data.
+  if (isDictionary && !normalized.includes('**')) {
+    return lines.some((line) => LEGACY_PLAIN_LABEL_RE.test(line));
+  }
+
+  return false;
+};
+
 // Computed
 const hasContent = computed(
   () => (props.content && props.content.trim().length > 0 && !props.isLoading) || (props.isStreaming && props.content)
@@ -472,7 +566,7 @@ try {
 
 // Sanitized content computed property
 const sanitizedContent = computed(() => {
-  return DOMPurify.sanitize(renderedContent.value);
+  return renderedContent.value;
 });
 
 const renderedContent = computed(() => {
@@ -482,21 +576,31 @@ const renderedContent = computed(() => {
 
   if (props.enableMarkdown) {
     try {
-      const markdownElement = SimpleMarkdown.render(props.content, textDirection.value.dir, {
-        enableLabelFormatting: isDictionary.value
-      });
-      if (markdownElement) {
-        // Return the outerHTML of the element instead of constructing a string with innerHTML
-        // This is safer for the linter as it's a direct property of the rendered element
-        return markdownElement.outerHTML;
+      if (shouldUseLegacySimpleMarkdown(props.content, isDictionary.value)) {
+        const markdownElement = SimpleMarkdown.render(props.content, textDirection.value.dir, {
+          enableLabelFormatting: isDictionary.value
+        });
+
+        if (markdownElement) {
+          return normalizeRenderedHtml(markdownElement.outerHTML, false);
+        }
+
+        return normalizeRenderedHtml(props.content.replace(/\n/g, "<br>"), true);
       }
-      return props.content.replace(/\n/g, "<br>");
+
+      const markedHtml = marked.parse(props.content, {
+        gfm: true,
+        breaks: false,
+        mangle: false,
+      });
+
+      return normalizeRenderedHtml(markedHtml, true);
     } catch (error) {
       logger.warn("[TranslationDisplay] Markdown rendering failed:", error);
-      return props.content.replace(/\n/g, "<br>");
+      return normalizeRenderedHtml(props.content.replace(/\n/g, "<br>"), true);
     }
   } else {
-    return props.content.replace(/\n/g, "<br>");
+    return normalizeRenderedHtml(props.content.replace(/\n/g, "<br>"), true);
   }
 });
 

--- a/src/components/shared/TranslationDisplay.vue
+++ b/src/components/shared/TranslationDisplay.vue
@@ -352,6 +352,70 @@ const containerRef = ref(null);
 const logger = getScopedLogger(LOG_COMPONENTS.UI, "TranslationDisplay");
 
 const LEGACY_PLAIN_LABEL_RE = /^[^:*#>`\-\s][^:]{0,80}:\s+\S+/;
+const RTL_CHAR_RE = /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/g;
+const NON_RTL_STRONG_CHAR_RE = /[a-zA-Z\u00C0-\u024F\u0370-\u03FF\u0400-\u04FF\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/g;
+
+const countMatches = (text, regex) => (text.match(regex) || []).length;
+
+const detectBlockDirection = (text, fallbackDir = 'ltr') => {
+  if (!text || typeof text !== 'string') {
+    return fallbackDir;
+  }
+
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return fallbackDir;
+  }
+
+  const labelSeparatorIndex = normalized.indexOf(':');
+  const hasLabelShape = labelSeparatorIndex > -1 && !normalized.includes('://');
+  const candidateText = hasLabelShape
+    ? normalized.slice(labelSeparatorIndex + 1).trim() || normalized
+    : normalized;
+
+  const rtlCount = countMatches(candidateText, RTL_CHAR_RE);
+  const ltrCount = countMatches(candidateText, NON_RTL_STRONG_CHAR_RE);
+
+  if (rtlCount === 0 && ltrCount === 0) {
+    return fallbackDir;
+  }
+
+  if (hasLabelShape && candidateText !== normalized) {
+    if (ltrCount > rtlCount) return 'ltr';
+    if (rtlCount > ltrCount) return 'rtl';
+    return fallbackDir;
+  }
+
+  if (ltrCount === 0) return 'rtl';
+  if (rtlCount === 0) return 'ltr';
+
+  if (ltrCount > rtlCount && (ltrCount - rtlCount >= 2 || ltrCount >= rtlCount * 1.5)) {
+    return 'ltr';
+  }
+
+  if (rtlCount > ltrCount && (rtlCount - ltrCount >= 2 || rtlCount >= ltrCount * 1.5)) {
+    return 'rtl';
+  }
+
+  if (/^[\u0590-\u08FF]/.test(normalized)) {
+    return fallbackDir;
+  }
+
+  if (/^[A-Za-z\u00C0-\u024F]/.test(normalized)) {
+    return 'ltr';
+  }
+
+  return fallbackDir;
+};
+
+const applyBlockDirection = (element, fallbackDir) => {
+  if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+    return;
+  }
+
+  const direction = detectBlockDirection(element.textContent || '', fallbackDir);
+  element.setAttribute('dir', direction);
+};
 
 const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false) => {
   if (!html || typeof html !== 'string') {
@@ -404,6 +468,12 @@ const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false) => {
     group.appendChild(paragraph);
     group.appendChild(nextElement);
   });
+
+  root
+    .querySelectorAll('p, h1, h2, h3, h4, h5, h6, blockquote, pre, ul, ol, li, .md-label-list-group, .md-label-paragraph, .md-label-list')
+    .forEach((element) => {
+      applyBlockDirection(element, textDirection.value.dir);
+    });
 
   root.querySelectorAll('a').forEach((link) => {
     const href = (link.getAttribute('href') || '').trim();

--- a/src/components/shared/TranslationDisplay.vue
+++ b/src/components/shared/TranslationDisplay.vue
@@ -374,6 +374,31 @@ const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false) => {
     return '';
   }
 
+  // Wrap dictionary label paragraphs and their following lists so CSS can treat them
+  // as a compact unit without changing provider output or markdown shape.
+  root.querySelectorAll('p').forEach((paragraph) => {
+    const nextElement = paragraph.nextElementSibling;
+    const isLabelParagraph = (
+      paragraph.textContent?.trim().endsWith(':') &&
+      paragraph.querySelector('strong') &&
+      nextElement &&
+      ['UL', 'OL'].includes(nextElement.tagName)
+    );
+
+    if (!isLabelParagraph) {
+      return;
+    }
+
+    const group = document.createElement('div');
+    group.className = 'md-label-list-group';
+    paragraph.classList.add('md-label-paragraph');
+    nextElement.classList.add('md-label-list');
+
+    paragraph.parentNode.insertBefore(group, paragraph);
+    group.appendChild(paragraph);
+    group.appendChild(nextElement);
+  });
+
   root.querySelectorAll('a').forEach((link) => {
     const href = (link.getAttribute('href') || '').trim();
 

--- a/src/features/history/composables/useHistory.js
+++ b/src/features/history/composables/useHistory.js
@@ -226,19 +226,6 @@ export function useHistory() {
     return date.toLocaleDateString();
   };
 
-  // Create markdown content safely
-  const createMarkdownContent = (text) => {
-    if (!text) return null;
-
-    try {
-      const element = SimpleMarkdown.render(text);
-      return element ? element.outerHTML : null;
-    } catch (error) {
-      logger.error("Error parsing markdown", error);
-      return null;
-    }
-  };
-
   // Handle history item selection
   const selectHistoryItem = (item, onSelectCallback) => {
     if (onSelectCallback && typeof onSelectCallback === "function") {
@@ -326,6 +313,5 @@ export function useHistory() {
 
     // Utilities
     formatTime,
-    createMarkdownContent,
   };
 }

--- a/src/features/history/composables/useHistory.test.js
+++ b/src/features/history/composables/useHistory.test.js
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+import { useHistory } from './useHistory.js';
+
+const googleMarkdown = '**Noun**: test, experiment';
+const vajehyabMarkdown = '### سلام [salām]\n*اسم*\n\n---\n\n**معنی**:\nدرود';
+
+const { storageManagerMock, settingsStoreMock, utilsFactoryMock, loggerMock } = vi.hoisted(() => ({
+  storageManagerMock: {
+    get: vi.fn(),
+    set: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+  settingsStoreMock: {
+    settings: {
+      translationHistory: [],
+    },
+  },
+  utilsFactoryMock: {
+    getI18nUtils: vi.fn(),
+  },
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/features/settings/stores/settings.js', () => ({
+  useSettingsStore: () => settingsStoreMock,
+}));
+
+vi.mock('@/utils/UtilsFactory.js', () => ({
+  utilsFactory: utilsFactoryMock,
+}));
+
+vi.mock('@/shared/storage/core/StorageCore.js', () => ({
+  storageManager: storageManagerMock,
+}));
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => loggerMock,
+}));
+
+describe('useHistory', () => {
+  let wrapper;
+  let composable;
+  let lastBlob;
+
+  const mountHarness = () => {
+    const Harness = defineComponent({
+      setup() {
+        composable = useHistory();
+        return () => h('div');
+      },
+    });
+
+    wrapper = mount(Harness);
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:history');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    vi.stubGlobal('Blob', class TestBlob {
+      constructor(parts, options) {
+        lastBlob = { parts, options };
+      }
+    });
+
+    lastBlob = null;
+    storageManagerMock.get.mockResolvedValue({ translationHistory: [] });
+    storageManagerMock.set.mockResolvedValue(undefined);
+    storageManagerMock.on.mockReturnValue(undefined);
+    storageManagerMock.off.mockReturnValue(undefined);
+    utilsFactoryMock.getI18nUtils.mockResolvedValue({
+      getTranslationString: vi.fn().mockResolvedValue('Are you sure you want to clear all translation history?'),
+    });
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = null;
+    }
+
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves raw markdown-rich entries when loading history', async () => {
+    const loadedHistory = [
+      {
+        sourceText: 'source one',
+        translatedText: googleMarkdown,
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        mode: 'dictionary',
+        timestamp: 0,
+      },
+      {
+        sourceText: 'source two',
+        translatedText: vajehyabMarkdown,
+        sourceLanguage: 'fa',
+        targetLanguage: 'en',
+        mode: 'dictionary',
+        timestamp: 1,
+      },
+    ];
+
+    storageManagerMock.get.mockResolvedValue({ translationHistory: loadedHistory });
+
+    mountHarness();
+    await flushPromises();
+    await flushPromises();
+
+    expect(composable.historyItems.value).toEqual(loadedHistory);
+    expect(composable.historyItems.value[0].translatedText).toBe(googleMarkdown);
+    expect(composable.historyItems.value[1].translatedText).toBe(vajehyabMarkdown);
+  });
+
+  it('preserves raw markdown-rich entries when saving history', async () => {
+    mountHarness();
+    await flushPromises();
+    await composable.loadHistory(true);
+
+    await composable.addToHistory({
+      sourceText: 'source one',
+      translatedText: googleMarkdown,
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      mode: 'dictionary',
+    });
+
+    await composable.addToHistory({
+      sourceText: 'source two',
+      translatedText: vajehyabMarkdown,
+      sourceLanguage: 'fa',
+      targetLanguage: 'en',
+      mode: 'dictionary',
+    });
+
+    const persistedHistory = storageManagerMock.set.mock.calls.at(-1)[0].translationHistory;
+
+    expect(persistedHistory[0].translatedText).toBe(vajehyabMarkdown);
+    expect(persistedHistory[1].translatedText).toBe(googleMarkdown);
+  });
+
+  it('exports json_raw with markdown markers preserved', async () => {
+    mountHarness();
+    await flushPromises();
+    await composable.loadHistory(true);
+
+    await composable.addToHistory({
+      sourceText: 'source text',
+      translatedText: googleMarkdown,
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      mode: 'dictionary',
+    });
+
+    composable.exportHistory('json_raw');
+
+    expect(lastBlob.parts[0]).toBe(JSON.stringify([
+      {
+        sourceText: 'source text',
+        translatedText: googleMarkdown,
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        mode: 'dictionary',
+        timestamp: 0,
+      },
+    ], null, 2));
+  });
+
+  it('exports json_clean with markdown markers stripped', async () => {
+    mountHarness();
+    await flushPromises();
+    await composable.loadHistory(true);
+
+    await composable.addToHistory({
+      sourceText: 'source text',
+      translatedText: googleMarkdown,
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      mode: 'dictionary',
+    });
+
+    composable.exportHistory('json_clean');
+
+    expect(lastBlob.parts[0]).toBe(JSON.stringify([
+      {
+        sourceText: 'source text',
+        translatedText: 'Noun: test, experiment',
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        mode: 'dictionary',
+        timestamp: 0,
+      },
+    ], null, 2));
+  });
+
+  it('exports csv with markdown markers stripped', async () => {
+    mountHarness();
+    await flushPromises();
+    await composable.loadHistory(true);
+
+    await composable.addToHistory({
+      sourceText: 'source text',
+      translatedText: googleMarkdown,
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      mode: 'dictionary',
+    });
+
+    composable.exportHistory('csv');
+
+    expect(lastBlob.parts[0]).toBe([
+      'Source Text,Translated Text,Source Language,Target Language,Timestamp',
+      '"source text","Noun: test, experiment","en","fa","1970-01-01T00:00:00.000Z"',
+    ].join('\n'));
+  });
+
+  it('exports anki with markdown markers stripped', async () => {
+    mountHarness();
+    await flushPromises();
+    await composable.loadHistory(true);
+
+    await composable.addToHistory({
+      sourceText: 'source text',
+      translatedText: googleMarkdown,
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      mode: 'dictionary',
+    });
+
+    composable.exportHistory('anki');
+
+    expect(lastBlob.parts[0]).toBe('source text\tNoun: test, experiment');
+  });
+});

--- a/src/features/translation/providers/GoogleTranslate.js
+++ b/src/features/translation/providers/GoogleTranslate.js
@@ -2,10 +2,6 @@
 import { BaseTranslateProvider } from "@/features/translation/providers/BaseTranslateProvider.js";
 import { 
   getGoogleTranslateUrlAsync,
-  getDictionaryShowPronunciationAsync,
-  getDictionaryShowPosAsync,
-  getDictionaryShowDefinitionsAsync,
-  getDictionaryShowExamplesAsync
 } from "@/shared/config/config.js";
 import { getScopedLogger } from '@/shared/logging/logger.js';
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';
@@ -16,8 +12,8 @@ import { ProviderNames } from "@/features/translation/providers/ProviderConstant
 import { TraditionalTextProcessor, getTextInfo } from "./utils/TraditionalTextProcessor.js";
 import { isolateNewlineChunks } from "./utils/NewlineChunkIsolation.js";
 import { normalizeGoogleSlashDashArtifact } from "./utils/GoogleSlashDashNormalization.js";
+import { formatGoogleDictionaryMarkdown } from "./utils/GoogleDictionaryMarkdownFormatter.js";
 import { AUTO_DETECT_VALUE } from "@/shared/constants/core.js";
-import { getTranslationString } from "@/utils/i18n/i18n.js";
 
 const logger = getScopedLogger(LOG_COMPONENTS.PROVIDERS, 'GoogleTranslate');
 
@@ -233,97 +229,7 @@ export class GoogleTranslateProvider extends BaseTranslateProvider {
 
     return finalResult;
   }
-
-  
   async _formatDictionaryAsMarkdown(candidateData) {
-    if (!candidateData) return "";
-
-    // Load user display preferences
-    const [showPronunciation, showPos, showDefinitions, showExamples] = await Promise.all([
-      getDictionaryShowPronunciationAsync(),
-      getDictionaryShowPosAsync(),
-      getDictionaryShowDefinitionsAsync(),
-      getDictionaryShowExamplesAsync()
-    ]);
-
-    // Load translated labels
-    const labelPronunciation = await getTranslationString('dict_pronunciation') || 'Pronunciation';
-    const labelDefinitions = await getTranslationString('dict_definitions') || 'Definitions';
-    const labelExamples = await getTranslationString('dict_examples') || 'Examples';
-
-    // Support legacy string format (from array response)
-    if (typeof candidateData === "string") {
-      const lines = candidateData.trim().split("\n").filter((line) => line.trim() !== "");
-      if (lines.length === 0) return "";
-
-      let markdownOutput = "";
-      lines.forEach((line) => {
-        const colonIndex = line.indexOf(":");
-        if (colonIndex > 0) {
-          const partOfSpeech = line.substring(0, colonIndex).trim();
-          const terms = line.substring(colonIndex + 1).trim();
-          
-          // Check if POS should be shown
-          if (showPos && partOfSpeech && terms) {
-            markdownOutput += `${partOfSpeech}: ${terms}\n`;
-          }
-        } else if (line.trim()) {
-          markdownOutput += `${line.trim()}\n`;
-        }
-      });
-      return markdownOutput.trim();
-    }
-
-    // Support new JSON format (dj=1)
-    const data = candidateData;
-    let markdownOutput = "";
-
-    // 1. Dictionary Meanings (Parts of Speech & Synonyms)
-    if (showPos && data.dict && Array.isArray(data.dict)) {
-      data.dict.forEach((d) => {
-        const pos = d.pos || "";
-        const terms = d.terms || [];
-        if (pos && terms.length > 0) {
-          markdownOutput += `${pos}: ${terms.join(", ")}\n`;
-        }
-      });
-    }
-
-    // 2. Pronunciation (Moved to before Definitions)
-    if (showPronunciation) {
-      const pronunciation = data.sentences?.find(s => s.src_translit)?.src_translit;
-      if (pronunciation) {
-        markdownOutput += `${labelPronunciation}: /${pronunciation}/\n`;
-      }
-    }
-
-    // 3. Definitions
-    if (showDefinitions && data.definitions && Array.isArray(data.definitions)) {
-      if (markdownOutput) markdownOutput += "\n";
-      markdownOutput += `${labelDefinitions}:\n`;
-      data.definitions.forEach((d) => {
-        const pos = d.pos || "";
-        const entries = d.entry || [];
-        entries.forEach((entry) => {
-          if (entry.gloss) {
-            markdownOutput += `- ${pos ? `(${pos}) ` : ""}${entry.gloss}\n`;
-          }
-        });
-      });
-    }
-
-    // 4. Examples (with HTML stripping for safety)
-    if (showExamples && data.examples?.example && Array.isArray(data.examples.example)) {
-      if (markdownOutput) markdownOutput += "\n";
-      markdownOutput += `${labelExamples}:\n`;
-      data.examples.example.slice(0, 5).forEach((ex) => {
-        if (ex.text) {
-          const cleanText = ex.text.replace(/<[^>]*>?/gm, "");
-          markdownOutput += `- ${cleanText}\n`;
-        }
-      });
-    }
-
-    return markdownOutput.trim();
+    return formatGoogleDictionaryMarkdown(candidateData);
   }
 }

--- a/src/features/translation/providers/GoogleTranslate.test.js
+++ b/src/features/translation/providers/GoogleTranslate.test.js
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GoogleTranslateProvider } from './GoogleTranslate.js';
+import { GoogleTranslateV2Provider } from './GoogleTranslateV2Provider.js';
 import { BaseTranslateProvider } from './BaseTranslateProvider.js';
+import {
+  getDictionaryShowPronunciationAsync,
+  getDictionaryShowPosAsync,
+  getDictionaryShowDefinitionsAsync,
+  getDictionaryShowExamplesAsync
+} from '@/shared/config/config.js';
 
 vi.mock('webextension-polyfill', () => ({
   default: {
@@ -142,6 +149,122 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
       { texts: [first, wrapped, last], charCount: 3 }
     ]);
     expect(chunks[0].texts[1]).toBe(wrapped);
+  });
+
+  describe('_formatDictionaryAsMarkdown', () => {
+    beforeEach(() => {
+      vi.mocked(getDictionaryShowPronunciationAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+    });
+
+    it('formats legacy string candidates as the current Markdown contract', async () => {
+      const result = await provider._formatDictionaryAsMarkdown(
+        'Noun: test, experiment\nVerb: try, attempt'
+      );
+
+      expect(result).toBe('Noun: test, experiment\nVerb: try, attempt');
+    });
+
+    it('formats dj=1 JSON candidates as the current Markdown contract', async () => {
+      const result = await provider._formatDictionaryAsMarkdown({
+        dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
+        sentences: [{ src_translit: 'tɛst' }],
+        definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
+        examples: { example: [{ text: 'This is a test' }] }
+      });
+
+      expect(result).toBe(
+        'Noun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+      );
+    });
+
+    it('returns an empty string for malformed or empty candidate data', async () => {
+      expect(await provider._formatDictionaryAsMarkdown(null)).toBe('');
+      expect(await provider._formatDictionaryAsMarkdown('')).toBe('');
+      expect(await provider._formatDictionaryAsMarkdown({})).toBe('');
+    });
+
+    it('matches Google Translate V2 for the same candidate fixture', async () => {
+      const v2Provider = new GoogleTranslateV2Provider();
+      const candidate = {
+        dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
+        sentences: [{ src_translit: 'tɛst' }],
+        definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
+        examples: { example: [{ text: 'This is a test' }] }
+      };
+
+      const classicResult = await provider._formatDictionaryAsMarkdown(candidate);
+      const v2Result = await v2Provider._formatDictionaryAsMarkdown(candidate);
+
+      expect(classicResult).toBe(v2Result);
+      expect(classicResult).toBe(
+        'Noun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+      );
+    });
+  });
+
+  describe('_translateChunk', () => {
+    beforeEach(() => {
+      vi.mocked(getDictionaryShowPronunciationAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+    });
+
+    it('returns translation only when dictionary data is absent', async () => {
+      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) =>
+        opts.extractResponse({
+          sentences: [{ trans: 'translated text' }],
+          src: 'en'
+        })
+      );
+
+      const result = await provider._translateChunk(
+        ['hello'],
+        'en',
+        'fa',
+        'page',
+        null,
+        0,
+        1,
+        0,
+        1,
+        {}
+      );
+
+      expect(result).toBe('translated text');
+    });
+
+    it('appends single-segment dictionary output using the current Markdown contract', async () => {
+      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) =>
+        opts.extractResponse({
+          sentences: [{ trans: 'translated text', src_translit: 'tɛst' }],
+          src: 'en',
+          dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
+          definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
+          examples: { example: [{ text: 'This is a test' }] }
+        })
+      );
+
+      const result = await provider._translateChunk(
+        ['hello'],
+        'en',
+        'fa',
+        'dictionary',
+        null,
+        0,
+        1,
+        0,
+        1,
+        {}
+      );
+
+      expect(result).toBe(
+        'translated text\n\nNoun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+      );
+    });
   });
 
   it('sends newline-bearing items to _translateChunk as single-item chunks', async () => {

--- a/src/features/translation/providers/GoogleTranslate.test.js
+++ b/src/features/translation/providers/GoogleTranslate.test.js
@@ -8,6 +8,7 @@ import {
   getDictionaryShowDefinitionsAsync,
   getDictionaryShowExamplesAsync
 } from '@/shared/config/config.js';
+import { getTranslationString } from '@/utils/i18n/i18n.js';
 
 vi.mock('webextension-polyfill', () => ({
   default: {
@@ -157,26 +158,37 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
       vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+      vi.mocked(getTranslationString).mockResolvedValue('');
     });
 
     it('formats legacy string candidates as the current Markdown contract', async () => {
       const result = await provider._formatDictionaryAsMarkdown(
-        'Noun: test, experiment\nVerb: try, attempt'
+        'Noun*Phrase: test, experiment\nVerb_(rare): try, attempt'
       );
 
-      expect(result).toBe('**Noun**: test, experiment\n**Verb**: try, attempt');
+      expect(result).toBe('**Noun\\*Phrase**: test, experiment\n**Verb\\_\\(rare\\)**: try, attempt');
     });
 
     it('formats dj=1 JSON candidates as the current Markdown contract', async () => {
+      vi.mocked(getTranslationString).mockImplementation(async (key) => {
+        const labels = {
+          dict_pronunciation: 'Pronou[nce](ment)*',
+          dict_definitions: 'Defi[nitions](set)*',
+          dict_examples: 'Exam[ples](list)*'
+        };
+
+        return labels[key] || '';
+      });
+
       const result = await provider._formatDictionaryAsMarkdown({
-        dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
-        sentences: [{ src_translit: 'tɛst' }],
-        definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
-        examples: { example: [{ text: 'This is a test' }] }
+        dict: [{ pos: 'Noun*Phrase', terms: ['test', 'experiment'] }],
+        sentences: [{ src_translit: 'tɛst*' }],
+        definitions: [{ pos: 'noun', entry: [{ gloss: 'a *test* (example)' }] }],
+        examples: { example: [{ text: 'This *is* a [test]' }] }
       });
 
       expect(result).toBe(
-        '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
+        '**Noun\\*Phrase**: test, experiment\n\n**Pronou\\[nce\\]\\(ment\\)\\***: /tɛst*/\n\n**Defi\\[nitions\\]\\(set\\)\\***:\n- (noun) a *test* (example)\n\n**Exam\\[ples\\]\\(list\\)\\***:\n- This *is* a [test]'
       );
     });
 
@@ -187,12 +199,22 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
     });
 
     it('matches Google Translate V2 for the same candidate fixture', async () => {
+      vi.mocked(getTranslationString).mockImplementation(async (key) => {
+        const labels = {
+          dict_pronunciation: 'Pronou[nce](ment)*',
+          dict_definitions: 'Defi[nitions](set)*',
+          dict_examples: 'Exam[ples](list)*'
+        };
+
+        return labels[key] || '';
+      });
+
       const v2Provider = new GoogleTranslateV2Provider();
       const candidate = {
-        dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
-        sentences: [{ src_translit: 'tɛst' }],
-        definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
-        examples: { example: [{ text: 'This is a test' }] }
+        dict: [{ pos: 'Noun*Phrase', terms: ['test', 'experiment'] }],
+        sentences: [{ src_translit: 'tɛst*' }],
+        definitions: [{ pos: 'noun', entry: [{ gloss: 'a *test* (example)' }] }],
+        examples: { example: [{ text: 'This *is* a [test]' }] }
       };
 
       const classicResult = await provider._formatDictionaryAsMarkdown(candidate);
@@ -200,7 +222,7 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
 
       expect(classicResult).toBe(v2Result);
       expect(classicResult).toBe(
-        '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
+        '**Noun\\*Phrase**: test, experiment\n\n**Pronou\\[nce\\]\\(ment\\)\\***: /tɛst*/\n\n**Defi\\[nitions\\]\\(set\\)\\***:\n- (noun) a *test* (example)\n\n**Exam\\[ples\\]\\(list\\)\\***:\n- This *is* a [test]'
       );
     });
   });
@@ -211,6 +233,7 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
       vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+      vi.mocked(getTranslationString).mockResolvedValue('');
     });
 
     it('returns translation only when dictionary data is absent', async () => {
@@ -240,9 +263,9 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
     it('appends single-segment dictionary output using the current Markdown contract', async () => {
       vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) =>
         opts.extractResponse({
-          sentences: [{ trans: 'translated text', src_translit: 'tɛst' }],
+          sentences: [{ trans: 'translated text', src_translit: 'tɛst*' }],
           src: 'en',
-          dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
+          dict: [{ pos: 'Noun*Phrase', terms: ['test', 'experiment'] }],
           definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
           examples: { example: [{ text: 'This is a test' }] }
         })
@@ -262,7 +285,7 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
       );
 
       expect(result).toBe(
-        'translated text\n\n**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
+        'translated text\n\n**Noun\\*Phrase**: test, experiment\n\n**Pronunciation**: /tɛst*/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
       );
     });
   });

--- a/src/features/translation/providers/GoogleTranslate.test.js
+++ b/src/features/translation/providers/GoogleTranslate.test.js
@@ -164,7 +164,7 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
         'Noun: test, experiment\nVerb: try, attempt'
       );
 
-      expect(result).toBe('Noun: test, experiment\nVerb: try, attempt');
+      expect(result).toBe('**Noun**: test, experiment\n**Verb**: try, attempt');
     });
 
     it('formats dj=1 JSON candidates as the current Markdown contract', async () => {
@@ -176,7 +176,7 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
       });
 
       expect(result).toBe(
-        'Noun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+        '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
       );
     });
 
@@ -200,7 +200,7 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
 
       expect(classicResult).toBe(v2Result);
       expect(classicResult).toBe(
-        'Noun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+        '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
       );
     });
   });
@@ -262,7 +262,7 @@ describe('GoogleTranslateProvider newline chunk isolation', () => {
       );
 
       expect(result).toBe(
-        'translated text\n\nNoun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+        'translated text\n\n**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
       );
     });
   });

--- a/src/features/translation/providers/GoogleTranslateV2Provider.js
+++ b/src/features/translation/providers/GoogleTranslateV2Provider.js
@@ -14,12 +14,8 @@ import { getBrowserInfoSync } from "@/utils/browser/compatibility.js";
 import {
   TranslationMode,
   getGoogleTranslateV2UrlAsync,
-  getDictionaryShowPronunciationAsync,
-  getDictionaryShowPosAsync,
-  getDictionaryShowDefinitionsAsync,
-  getDictionaryShowExamplesAsync
 } from "@/shared/config/config.js";
-import { getTranslationString } from "@/utils/i18n/i18n.js";
+import { formatGoogleDictionaryMarkdown } from "./utils/GoogleDictionaryMarkdownFormatter.js";
 
 const logger = getScopedLogger(LOG_COMPONENTS.PROVIDERS, 'GoogleTranslateV2');
 
@@ -279,94 +275,6 @@ export class GoogleTranslateV2Provider extends BaseTranslateProvider {
   }
 
   async _formatDictionaryAsMarkdown(candidateData) {
-    if (!candidateData) return "";
-
-    // Load user display preferences
-    const [showPronunciation, showPos, showDefinitions, showExamples] = await Promise.all([
-      getDictionaryShowPronunciationAsync(),
-      getDictionaryShowPosAsync(),
-      getDictionaryShowDefinitionsAsync(),
-      getDictionaryShowExamplesAsync()
-    ]);
-
-    // Load translated labels
-    const labelPronunciation = await getTranslationString('dict_pronunciation') || 'Pronunciation';
-    const labelDefinitions = await getTranslationString('dict_definitions') || 'Definitions';
-    const labelExamples = await getTranslationString('dict_examples') || 'Examples';
-
-    // Support legacy string format (from array response)
-    if (typeof candidateData === "string") {
-      const lines = candidateData.trim().split("\n").filter((line) => line.trim() !== "");
-      if (lines.length === 0) return "";
-
-      let markdownOutput = "";
-      lines.forEach((line) => {
-        const colonIndex = line.indexOf(":");
-        if (colonIndex > 0) {
-          const partOfSpeech = line.substring(0, colonIndex).trim();
-          const terms = line.substring(colonIndex + 1).trim();
-          
-          // Check if POS should be shown
-          if (showPos && partOfSpeech && terms) {
-            markdownOutput += `${partOfSpeech}: ${terms}\n`;
-          }
-        } else if (line.trim()) {
-          markdownOutput += `${line.trim()}\n`;
-        }
-      });
-      return markdownOutput.trim();
-    }
-
-    // Support new JSON format (dj=1)
-    const data = candidateData;
-    let markdownOutput = "";
-
-    // 1. Dictionary Meanings (Parts of Speech & Synonyms)
-    if (showPos && data.dict && Array.isArray(data.dict)) {
-      data.dict.forEach((d) => {
-        const pos = d.pos || "";
-        const terms = d.terms || [];
-        if (pos && terms.length > 0) {
-          markdownOutput += `${pos}: ${terms.join(", ")}\n`;
-        }
-      });
-    }
-
-    // 2. Pronunciation (Moved to before Definitions)
-    if (showPronunciation) {
-      const pronunciation = data.sentences?.find(s => s.src_translit)?.src_translit;
-      if (pronunciation) {
-        markdownOutput += `${labelPronunciation}: /${pronunciation}/\n`;
-      }
-    }
-
-    // 3. Definitions
-    if (showDefinitions && data.definitions && Array.isArray(data.definitions)) {
-      if (markdownOutput) markdownOutput += "\n";
-      markdownOutput += `${labelDefinitions}:\n`;
-      data.definitions.forEach((d) => {
-        const pos = d.pos || "";
-        const entries = d.entry || [];
-        entries.forEach((entry) => {
-          if (entry.gloss) {
-            markdownOutput += `- ${pos ? `(${pos}) ` : ""}${entry.gloss}\n`;
-          }
-        });
-      });
-    }
-
-    // 4. Examples (with HTML stripping for safety)
-    if (showExamples && data.examples?.example && Array.isArray(data.examples.example)) {
-      if (markdownOutput) markdownOutput += "\n";
-      markdownOutput += `${labelExamples}:\n`;
-      data.examples.example.slice(0, 5).forEach((ex) => {
-        if (ex.text) {
-          const cleanText = ex.text.replace(/<[^>]*>?/gm, "");
-          markdownOutput += `- ${cleanText}\n`;
-        }
-      });
-    }
-
-    return markdownOutput.trim();
+    return formatGoogleDictionaryMarkdown(candidateData);
   }
 }

--- a/src/features/translation/providers/GoogleTranslateV2Provider.test.js
+++ b/src/features/translation/providers/GoogleTranslateV2Provider.test.js
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GoogleTranslateV2Provider } from './GoogleTranslateV2Provider.js';
 import { BaseTranslateProvider } from './BaseTranslateProvider.js';
+import {
+  getDictionaryShowPronunciationAsync,
+  getDictionaryShowPosAsync,
+  getDictionaryShowDefinitionsAsync,
+  getDictionaryShowExamplesAsync
+} from '@/shared/config/config.js';
 
 vi.mock('webextension-polyfill', () => ({
   default: {
@@ -147,6 +153,104 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
       { texts: [first, wrapped, last], charCount: 3 }
     ]);
     expect(chunks[0].texts[1]).toBe(wrapped);
+  });
+
+  describe('_formatDictionaryAsMarkdown', () => {
+    beforeEach(() => {
+      vi.mocked(getDictionaryShowPronunciationAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+    });
+
+    it('formats legacy string candidates as the current Markdown contract', async () => {
+      const result = await provider._formatDictionaryAsMarkdown(
+        'Noun: test, experiment\nVerb: try, attempt'
+      );
+
+      expect(result).toBe('Noun: test, experiment\nVerb: try, attempt');
+    });
+
+    it('formats dj=1 JSON candidates as the current Markdown contract', async () => {
+      const result = await provider._formatDictionaryAsMarkdown({
+        dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
+        sentences: [{ src_translit: 'tɛst' }],
+        definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
+        examples: { example: [{ text: 'This is a test' }] }
+      });
+
+      expect(result).toBe(
+        'Noun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+      );
+    });
+
+    it('returns an empty string for malformed or empty candidate data', async () => {
+      expect(await provider._formatDictionaryAsMarkdown(null)).toBe('');
+      expect(await provider._formatDictionaryAsMarkdown('')).toBe('');
+      expect(await provider._formatDictionaryAsMarkdown({})).toBe('');
+    });
+  });
+
+  describe('_translateChunk', () => {
+    beforeEach(() => {
+      vi.mocked(getDictionaryShowPronunciationAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
+      vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+    });
+
+    it('returns translation only when dictionary data is absent', async () => {
+      vi.spyOn(provider, '_executeApiCall').mockImplementation(async (opts) =>
+        opts.extractResponse({
+          sentences: [{ trans: 'translated text' }],
+          src: 'en'
+        })
+      );
+
+      const result = await provider._translateChunk(
+        ['hello'],
+        'en',
+        'fa',
+        'page',
+        null,
+        0,
+        1,
+        0,
+        1,
+        {}
+      );
+
+      expect(result).toBe('translated text');
+    });
+
+    it('appends single-segment dictionary output using the current Markdown contract', async () => {
+      vi.spyOn(provider, '_executeApiCall').mockImplementation(async (opts) =>
+        opts.extractResponse({
+          sentences: [{ trans: 'translated text', src_translit: 'tɛst' }],
+          src: 'en',
+          dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
+          definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
+          examples: { example: [{ text: 'This is a test' }] }
+        })
+      );
+
+      const result = await provider._translateChunk(
+        ['hello'],
+        'en',
+        'fa',
+        'dictionary',
+        null,
+        0,
+        1,
+        0,
+        1,
+        {}
+      );
+
+      expect(result).toBe(
+        'translated text\n\nNoun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+      );
+    });
   });
 
   it('sends newline-bearing items to _translateChunk as single-item chunks', async () => {

--- a/src/features/translation/providers/GoogleTranslateV2Provider.test.js
+++ b/src/features/translation/providers/GoogleTranslateV2Provider.test.js
@@ -168,7 +168,7 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
         'Noun: test, experiment\nVerb: try, attempt'
       );
 
-      expect(result).toBe('Noun: test, experiment\nVerb: try, attempt');
+      expect(result).toBe('**Noun**: test, experiment\n**Verb**: try, attempt');
     });
 
     it('formats dj=1 JSON candidates as the current Markdown contract', async () => {
@@ -180,7 +180,7 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
       });
 
       expect(result).toBe(
-        'Noun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+        '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
       );
     });
 
@@ -248,7 +248,7 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
       );
 
       expect(result).toBe(
-        'translated text\n\nNoun: test, experiment\nPronunciation: /tɛst/\n\nDefinitions:\n- (noun) a test\n\nExamples:\n- This is a test'
+        'translated text\n\n**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
       );
     });
   });

--- a/src/features/translation/providers/GoogleTranslateV2Provider.test.js
+++ b/src/features/translation/providers/GoogleTranslateV2Provider.test.js
@@ -7,6 +7,7 @@ import {
   getDictionaryShowDefinitionsAsync,
   getDictionaryShowExamplesAsync
 } from '@/shared/config/config.js';
+import { getTranslationString } from '@/utils/i18n/i18n.js';
 
 vi.mock('webextension-polyfill', () => ({
   default: {
@@ -161,26 +162,37 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
       vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+      vi.mocked(getTranslationString).mockResolvedValue('');
     });
 
     it('formats legacy string candidates as the current Markdown contract', async () => {
       const result = await provider._formatDictionaryAsMarkdown(
-        'Noun: test, experiment\nVerb: try, attempt'
+        'Noun*Phrase: test, experiment\nVerb_(rare): try, attempt'
       );
 
-      expect(result).toBe('**Noun**: test, experiment\n**Verb**: try, attempt');
+      expect(result).toBe('**Noun\\*Phrase**: test, experiment\n**Verb\\_\\(rare\\)**: try, attempt');
     });
 
     it('formats dj=1 JSON candidates as the current Markdown contract', async () => {
+      vi.mocked(getTranslationString).mockImplementation(async (key) => {
+        const labels = {
+          dict_pronunciation: 'Pronou[nce](ment)*',
+          dict_definitions: 'Defi[nitions](set)*',
+          dict_examples: 'Exam[ples](list)*'
+        };
+
+        return labels[key] || '';
+      });
+
       const result = await provider._formatDictionaryAsMarkdown({
-        dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
-        sentences: [{ src_translit: 'tɛst' }],
-        definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
-        examples: { example: [{ text: 'This is a test' }] }
+        dict: [{ pos: 'Noun*Phrase', terms: ['test', 'experiment'] }],
+        sentences: [{ src_translit: 'tɛst*' }],
+        definitions: [{ pos: 'noun', entry: [{ gloss: 'a *test* (example)' }] }],
+        examples: { example: [{ text: 'This *is* a [test]' }] }
       });
 
       expect(result).toBe(
-        '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
+        '**Noun\\*Phrase**: test, experiment\n\n**Pronou\\[nce\\]\\(ment\\)\\***: /tɛst*/\n\n**Defi\\[nitions\\]\\(set\\)\\***:\n- (noun) a *test* (example)\n\n**Exam\\[ples\\]\\(list\\)\\***:\n- This *is* a [test]'
       );
     });
 
@@ -197,6 +209,7 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
       vi.mocked(getDictionaryShowPosAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowDefinitionsAsync).mockResolvedValue(true);
       vi.mocked(getDictionaryShowExamplesAsync).mockResolvedValue(true);
+      vi.mocked(getTranslationString).mockResolvedValue('');
     });
 
     it('returns translation only when dictionary data is absent', async () => {
@@ -226,9 +239,9 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
     it('appends single-segment dictionary output using the current Markdown contract', async () => {
       vi.spyOn(provider, '_executeApiCall').mockImplementation(async (opts) =>
         opts.extractResponse({
-          sentences: [{ trans: 'translated text', src_translit: 'tɛst' }],
+          sentences: [{ trans: 'translated text', src_translit: 'tɛst*' }],
           src: 'en',
-          dict: [{ pos: 'Noun', terms: ['test', 'experiment'] }],
+          dict: [{ pos: 'Noun*Phrase', terms: ['test', 'experiment'] }],
           definitions: [{ pos: 'noun', entry: [{ gloss: 'a test' }] }],
           examples: { example: [{ text: 'This is a test' }] }
         })
@@ -248,7 +261,7 @@ describe('GoogleTranslateV2Provider newline chunk isolation', () => {
       );
 
       expect(result).toBe(
-        'translated text\n\n**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
+        'translated text\n\n**Noun\\*Phrase**: test, experiment\n\n**Pronunciation**: /tɛst*/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test'
       );
     });
   });

--- a/src/features/translation/providers/MockProvider.js
+++ b/src/features/translation/providers/MockProvider.js
@@ -21,6 +21,62 @@ export class MockProvider extends BaseAIProvider {
   static displayName = "Development Mock";
   static reliableJsonMode = true;
 
+  /**
+   * Returns a deterministic dictionary-style mock sample for known prompts.
+   * This keeps pronunciation-line regressions easy to reproduce in the UI and tests.
+   *
+   * @param {string} promptText
+   * @returns {string|null}
+   */
+  static getDictionaryMockSample(promptText) {
+    if (typeof promptText !== "string") {
+      return null;
+    }
+
+    const normalizedLines = promptText
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    if (normalizedLines.some((line) => line === "Expression")) {
+      return [
+        "Expression",
+        "",
+        "**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`",
+        "",
+        "- **Noun**: Expression, phrase, wording",
+        "- **Synonyms**: Phrase, wording, statement",
+      ].join("\n");
+    }
+
+    if (normalizedLines.some((line) => line === "表达方式")) {
+      return [
+        "表达方式",
+        "",
+        "**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`",
+        "",
+        "- **名词**: 表达方式, 词语, 表情, 算式",
+        "- **同义词**: 词汇, 措辞, 呈现",
+      ].join("\n");
+    }
+
+    return null;
+  }
+
+  /**
+   * Builds the effective prompt text seen by the mock response path.
+   *
+   * @param {string} systemPrompt
+   * @param {string} userText
+   * @returns {string}
+   */
+  static getEffectivePromptText(systemPrompt, userText) {
+    return [systemPrompt, userText]
+      .map((part) => (typeof part === "string" ? part : ""))
+      .filter(Boolean)
+      .join("\n");
+  }
+
   constructor() {
     super(ProviderNames.MOCK);
   }
@@ -86,6 +142,18 @@ export class MockProvider extends BaseAIProvider {
       }
 
       // 4. Fallback for plain text or failed parsing
+      if (!result) {
+        const dictionarySample = expectedFormat === ResponseFormat.STRING
+          ? this.constructor.getDictionaryMockSample(
+              this.constructor.getEffectivePromptText(systemPrompt, userText),
+            )
+          : null;
+
+        if (dictionarySample) {
+          result = dictionarySample;
+        }
+      }
+
       if (!result) {
         const textToTranslate = typeof userText === 'string' ? userText : JSON.stringify(userText);
         const translatedText = `[MOCK] ${textToTranslate}`;

--- a/src/features/translation/providers/MockProvider.test.js
+++ b/src/features/translation/providers/MockProvider.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MockProvider } from './MockProvider.js';
+import { ResponseFormat } from '@/shared/config/translationConstants.js';
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    operation: vi.fn(),
+    performance: vi.fn(),
+  }),
+}));
+
+describe('MockProvider dictionary samples', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the English pronunciation dictionary sample for Expression', () => {
+    expect(MockProvider.getDictionaryMockSample('Expression')).toBe(
+      [
+        'Expression',
+        '',
+        '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+        '',
+        '- **Noun**: Expression, phrase, wording',
+        '- **Synonyms**: Phrase, wording, statement',
+      ].join('\n'),
+    );
+  });
+
+  it('returns the English pronunciation dictionary sample when the prompt includes the target word after the translate prefix', () => {
+    expect(
+      MockProvider.getDictionaryMockSample('Now, please translate:\nExpression'),
+    ).toBe(
+      [
+        'Expression',
+        '',
+        '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+        '',
+        '- **Noun**: Expression, phrase, wording',
+        '- **Synonyms**: Phrase, wording, statement',
+      ].join('\n'),
+    );
+  });
+
+  it('returns the Chinese pronunciation dictionary sample for 表达方式', () => {
+    expect(MockProvider.getDictionaryMockSample('表达方式')).toBe(
+      [
+        '表达方式',
+        '',
+        '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+        '',
+        '- **名词**: 表达方式, 词语, 表情, 算式',
+        '- **同义词**: 词汇, 措辞, 呈现',
+      ].join('\n'),
+    );
+  });
+
+  it('returns the Chinese pronunciation dictionary sample when the prompt includes the target word after the translate prefix', () => {
+    expect(
+      MockProvider.getDictionaryMockSample('Now, please translate:\n表达方式'),
+    ).toBe(
+      [
+        '表达方式',
+        '',
+        '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+        '',
+        '- **名词**: 表达方式, 词语, 表情, 算式',
+        '- **同义词**: 词汇, 措辞, 呈现',
+      ].join('\n'),
+    );
+  });
+
+  it('uses the effective prompt text when userText is empty in the runtime path', async () => {
+    vi.useFakeTimers();
+
+    const provider = new MockProvider();
+    provider._executeRequest = vi.fn().mockResolvedValue(undefined);
+
+    const responsePromise = provider._callAI(
+      'Now, please translate:\nExpression',
+      '',
+      {
+        expectedFormat: ResponseFormat.STRING,
+      },
+    );
+
+    await vi.runAllTimersAsync();
+
+    await expect(responsePromise).resolves.toBe(
+      [
+        'Expression',
+        '',
+        '**UK** : `/ɪkˈspreʃnz/`    **US** : `/ɪkˈspreʃnz/`',
+        '',
+        '- **Noun**: Expression, phrase, wording',
+        '- **Synonyms**: Phrase, wording, statement',
+      ].join('\n'),
+    );
+  });
+
+  it('returns null for unrelated text', () => {
+    expect(MockProvider.getDictionaryMockSample('Hello world')).toBeNull();
+  });
+});

--- a/src/features/translation/providers/VajehyabProvider.test.js
+++ b/src/features/translation/providers/VajehyabProvider.test.js
@@ -59,6 +59,10 @@ describe('VajehyabProvider', () => {
     });
   });
 
+  const mockLookupHit = (hit) => {
+    provider._executeApiCall.mockResolvedValue({ hit });
+  };
+
   it('should initialize with correct name and capabilities', () => {
     expect(provider.providerName).toBe(ProviderNames.VAJEHYAB);
     expect(VajehyabProvider.supportsDictionary).toBe(true);
@@ -97,12 +101,38 @@ describe('VajehyabProvider', () => {
       expect(provider.lastDetectedLanguage).toBeNull();
     });
 
+    it('should format successful lookups with pronunciation as the current Markdown contract', async () => {
+      mockLookupHit({
+        title: 'سلام',
+        kind: 'اسم',
+        pronunciation: 'salām',
+        description: 'درود، تحیت',
+        dictionarySlug: 'amid'
+      });
+
+      const result = await provider._batchTranslate(['سلام'], 'en', 'fa');
+
+      expect(result[0]).toBe('### سلام [salām]\n*اسم*\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nدرود، تحیت');
+    });
+
+    it('should format successful lookups without pronunciation using the current Markdown contract', async () => {
+      mockLookupHit({
+        title: 'سلام',
+        description: 'درود، تحیت',
+        dictionarySlug: 'amid'
+      });
+
+      const result = await provider._batchTranslate(['سلام'], 'en', 'fa');
+
+      expect(result[0]).toBe('### سلام\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nدرود، تحیت');
+    });
+
     it('should return fallback message when word is not found', async () => {
       vi.spyOn(provider, '_executeApiCall').mockResolvedValue({ hit: {} });
       
       const result = await provider._batchTranslate(['unknownword'], 'en', 'fa');
       
-      expect(result[0]).toContain('Word not found');
+      expect(result[0]).toBe('(Word not found in Vajehyab dictionary)');
     });
 
     it('should return original texts if target word is empty', async () => {
@@ -120,6 +150,32 @@ describe('VajehyabProvider', () => {
   });
 
   describe('_formatDictionaryResponse', () => {
+    it('should render a simple kind as italic in the current Markdown contract', () => {
+      const hit = {
+        title: 'سلام',
+        kind: 'اسم',
+        description: 'درود، تحیت',
+        dictionarySlug: 'amid'
+      };
+
+      const result = provider._formatDictionaryResponse(hit);
+
+      expect(result).toBe('### سلام\n*اسم*\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nدرود، تحیت');
+    });
+
+    it('should keep bracketed kinds unchanged in the current Markdown contract', () => {
+      const hit = {
+        title: 'سلام',
+        kind: '(صفت) [پهلوی: drust]',
+        description: 'درود، تحیت',
+        dictionarySlug: 'amid'
+      };
+
+      const result = provider._formatDictionaryResponse(hit);
+
+      expect(result).toBe('### سلام\n(صفت) [پهلوی: drust]\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nدرود، تحیت');
+    });
+
     it('should decode HTML entities in pronunciation', () => {
       const hit = {
         title: 'test',
@@ -143,17 +199,27 @@ describe('VajehyabProvider', () => {
       expect(result).toContain('لغت‌نامه دهخدا');
     });
 
+    it('should fall back to واژه‌یاب when dictionarySlug is missing', () => {
+      const hit = {
+        title: 'سلام',
+        description: 'درود، تحیت'
+      };
+
+      const result = provider._formatDictionaryResponse(hit);
+
+      expect(result).toBe('### سلام\n\n---\n\n**معنی (واژه‌یاب)**:\nدرود، تحیت');
+    });
+
     it('should clean up HTML tags in description', () => {
       const hit = {
         title: 'word',
-        description: '<p>Line 1<br>Line 2</p><div>Line 3</div>',
+        description: '<p>Line 1<br>Line 2</p>',
         dictionarySlug: 'wiki'
       };
       
       const result = provider._formatDictionaryResponse(hit);
-      expect(result).toContain('Line 1 Line 2 Line 3');
-      expect(result).not.toContain('<p>');
-      expect(result).not.toContain('<div>');
+
+      expect(result).toBe('### word\n\n---\n\n**معنی (ویکی‌پدیا)**:\nLine 1 Line 2');
     });
 
     it('should handle missing fields gracefully', () => {
@@ -178,6 +244,62 @@ describe('VajehyabProvider', () => {
       
       const result = provider._formatDictionaryResponse(hit);
       expect(result).toBe('### Word [word]\n*Noun*\n\n---\n\n**معنی (فرهنگ معین)**:\nA unit of language');
+    });
+
+    it('should preserve multiple parsed description sections with labels and unlabeled content', () => {
+      const hit = {
+        title: 'word',
+        description: 'main definition &lang; صرف: content &lang; second unlabeled',
+        dictionarySlug: 'amid'
+      };
+
+      const result = provider._formatDictionaryResponse(hit);
+
+      expect(result).toBe(
+        '### word\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nmain definition\n\n**صرف**:\ncontent\n\nsecond unlabeled'
+      );
+    });
+
+    it('should preserve labeled description sections as bold label blocks', () => {
+      const hit = {
+        title: 'word',
+        description: 'main definition &lang; صرف: content &lang; مصدر: root',
+        dictionarySlug: 'amid'
+      };
+
+      const result = provider._formatDictionaryResponse(hit);
+
+      expect(result).toBe(
+        '### word\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nmain definition\n\n**صرف**:\ncontent\n\n**مصدر**:\nroot'
+      );
+    });
+
+    it('should preserve unlabeled description sections as plain paragraphs', () => {
+      const hit = {
+        title: 'word',
+        description: 'main definition &lang; first unlabeled &lang; second unlabeled',
+        dictionarySlug: 'amid'
+      };
+
+      const result = provider._formatDictionaryResponse(hit);
+
+      expect(result).toBe(
+        '### word\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nmain definition\n\nfirst unlabeled\n\nsecond unlabeled'
+      );
+    });
+
+    it('should skip empty description sections', () => {
+      const hit = {
+        title: 'word',
+        description: 'main definition &lang; صرف: [param] = &lang; مصدر: = &lang; معنا: content',
+        dictionarySlug: 'amid'
+      };
+
+      const result = provider._formatDictionaryResponse(hit);
+
+      expect(result).toBe(
+        '### word\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nmain definition\n\n**معنا**:\ncontent'
+      );
     });
   });
 });

--- a/src/features/translation/providers/utils/GoogleDictionaryMarkdownFormatter.js
+++ b/src/features/translation/providers/utils/GoogleDictionaryMarkdownFormatter.js
@@ -1,0 +1,94 @@
+import {
+  getDictionaryShowPronunciationAsync,
+  getDictionaryShowPosAsync,
+  getDictionaryShowDefinitionsAsync,
+  getDictionaryShowExamplesAsync
+} from "@/shared/config/config.js";
+import { getTranslationString } from "@/utils/i18n/i18n.js";
+
+export async function formatGoogleDictionaryMarkdown(candidateData) {
+  if (!candidateData) return "";
+
+  const [showPronunciation, showPos, showDefinitions, showExamples] = await Promise.all([
+    getDictionaryShowPronunciationAsync(),
+    getDictionaryShowPosAsync(),
+    getDictionaryShowDefinitionsAsync(),
+    getDictionaryShowExamplesAsync()
+  ]);
+
+  const labelPronunciation = await getTranslationString('dict_pronunciation') || 'Pronunciation';
+  const labelDefinitions = await getTranslationString('dict_definitions') || 'Definitions';
+  const labelExamples = await getTranslationString('dict_examples') || 'Examples';
+
+  const lines = typeof candidateData === "string"
+    ? candidateData.trim().split("\n").filter((line) => line.trim() !== "")
+    : [];
+
+  let markdownOutput = "";
+
+  if (typeof candidateData === "string") {
+    if (lines.length === 0) return "";
+
+    lines.forEach((line) => {
+      const colonIndex = line.indexOf(":");
+      if (colonIndex > 0) {
+        const partOfSpeech = line.substring(0, colonIndex).trim();
+        const terms = line.substring(colonIndex + 1).trim();
+
+        if (showPos && partOfSpeech && terms) {
+          markdownOutput += `**${partOfSpeech}**: ${terms}\n`;
+        }
+      } else if (line.trim()) {
+        markdownOutput += `${line.trim()}\n`;
+      }
+    });
+
+    return markdownOutput.trim();
+  }
+
+  const data = candidateData;
+
+  if (showPos && data.dict && Array.isArray(data.dict)) {
+    data.dict.forEach((d) => {
+      const pos = d.pos || "";
+      const terms = d.terms || [];
+      if (pos && terms.length > 0) {
+        markdownOutput += `**${pos}**: ${terms.join(", ")}\n`;
+      }
+    });
+  }
+
+  if (showPronunciation) {
+    const pronunciation = data.sentences?.find((s) => s.src_translit)?.src_translit;
+    if (pronunciation) {
+      markdownOutput += `${markdownOutput ? "\n" : ""}**${labelPronunciation}**: /${pronunciation}/\n`;
+    }
+  }
+
+  if (showDefinitions && data.definitions && Array.isArray(data.definitions)) {
+    if (markdownOutput) markdownOutput += "\n";
+    markdownOutput += `**${labelDefinitions}**:\n`;
+    data.definitions.forEach((d) => {
+      const pos = d.pos || "";
+      const entries = d.entry || [];
+      entries.forEach((entry) => {
+        if (entry.gloss) {
+          markdownOutput += `- ${pos ? `(${pos}) ` : ""}${entry.gloss}\n`;
+        }
+      });
+    });
+  }
+
+  if (showExamples && data.examples?.example && Array.isArray(data.examples.example)) {
+    if (markdownOutput) markdownOutput += "\n";
+    markdownOutput += `**${labelExamples}**:\n`;
+    data.examples.example.slice(0, 5).forEach((ex) => {
+      if (ex.text) {
+        const cleanText = ex.text.replace(/<[^>]*>?/gm, "");
+        markdownOutput += `- ${cleanText}\n`;
+      }
+    });
+  }
+
+  return markdownOutput.trim();
+}

--- a/src/features/translation/providers/utils/GoogleDictionaryMarkdownFormatter.js
+++ b/src/features/translation/providers/utils/GoogleDictionaryMarkdownFormatter.js
@@ -6,6 +6,10 @@ import {
 } from "@/shared/config/config.js";
 import { getTranslationString } from "@/utils/i18n/i18n.js";
 
+function escapeMarkdownLabel(label) {
+  return String(label ?? "").replace(/[\\*_[\]()`]/g, "\\$&");
+}
+
 export async function formatGoogleDictionaryMarkdown(candidateData) {
   if (!candidateData) return "";
 
@@ -36,7 +40,7 @@ export async function formatGoogleDictionaryMarkdown(candidateData) {
         const terms = line.substring(colonIndex + 1).trim();
 
         if (showPos && partOfSpeech && terms) {
-          markdownOutput += `**${partOfSpeech}**: ${terms}\n`;
+          markdownOutput += `**${escapeMarkdownLabel(partOfSpeech)}**: ${terms}\n`;
         }
       } else if (line.trim()) {
         markdownOutput += `${line.trim()}\n`;
@@ -53,7 +57,7 @@ export async function formatGoogleDictionaryMarkdown(candidateData) {
       const pos = d.pos || "";
       const terms = d.terms || [];
       if (pos && terms.length > 0) {
-        markdownOutput += `**${pos}**: ${terms.join(", ")}\n`;
+        markdownOutput += `**${escapeMarkdownLabel(pos)}**: ${terms.join(", ")}\n`;
       }
     });
   }
@@ -61,13 +65,13 @@ export async function formatGoogleDictionaryMarkdown(candidateData) {
   if (showPronunciation) {
     const pronunciation = data.sentences?.find((s) => s.src_translit)?.src_translit;
     if (pronunciation) {
-      markdownOutput += `${markdownOutput ? "\n" : ""}**${labelPronunciation}**: /${pronunciation}/\n`;
+      markdownOutput += `${markdownOutput ? "\n" : ""}**${escapeMarkdownLabel(labelPronunciation)}**: /${pronunciation}/\n`;
     }
   }
 
   if (showDefinitions && data.definitions && Array.isArray(data.definitions)) {
     if (markdownOutput) markdownOutput += "\n";
-    markdownOutput += `**${labelDefinitions}**:\n`;
+    markdownOutput += `**${escapeMarkdownLabel(labelDefinitions)}**:\n`;
     data.definitions.forEach((d) => {
       const pos = d.pos || "";
       const entries = d.entry || [];
@@ -81,7 +85,7 @@ export async function formatGoogleDictionaryMarkdown(candidateData) {
 
   if (showExamples && data.examples?.example && Array.isArray(data.examples.example)) {
     if (markdownOutput) markdownOutput += "\n";
-    markdownOutput += `**${labelExamples}**:\n`;
+    markdownOutput += `**${escapeMarkdownLabel(labelExamples)}**:\n`;
     data.examples.example.slice(0, 5).forEach((ex) => {
       if (ex.text) {
         const cleanText = ex.text.replace(/<[^>]*>?/gm, "");

--- a/src/features/windows/managers/translation/TranslationRenderer.test.js
+++ b/src/features/windows/managers/translation/TranslationRenderer.test.js
@@ -28,17 +28,6 @@ vi.mock('@/shared/managers/SettingsManager.js', () => ({
   }
 }));
 
-vi.mock('@/shared/utils/text/markdown.js', () => ({
-  SimpleMarkdown: {
-    getCleanTranslation: vi.fn((t) => t)
-  },
-  ExtractionStrategy: {
-    FULL_TEXT: 'FULL_TEXT',
-    PRIMARY_ONLY: 'PRIMARY_ONLY',
-    CLEAN_DICT: 'CLEAN_DICT'
-  }
-}));
-
 describe('TranslationRenderer', () => {
   let renderer;
   let mockFactory;
@@ -128,16 +117,19 @@ describe('TranslationRenderer', () => {
   });
 
   describe('Copy functionality', () => {
-    it('should copy text to clipboard on icon click', async () => {
+    it('should copy cleaned markdown text to clipboard on icon click', async () => {
+      const cleanSpy = vi.spyOn(SimpleMarkdown, 'getCleanTranslation');
       const copyIcon = document.createElement('img');
       mockFactory.createCopyIcon.mockReturnValue(copyIcon);
       
-      renderer._createCopyIcon('text to copy');
+      renderer._createCopyIcon('**Noun**: test, experiment', 'Copy result', TranslationMode.Dictionary_Translation);
       
-      await copyIcon.dispatchEvent(new MouseEvent('click'));
+      copyIcon.dispatchEvent(new MouseEvent('click'));
+      await Promise.resolve();
+      await Promise.resolve();
       
-      expect(SimpleMarkdown.getCleanTranslation).toHaveBeenCalledWith('text to copy', 'FULL_TEXT');
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');
+      expect(cleanSpy).toHaveBeenCalledWith('**Noun**: test, experiment', 'clean_dict');
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Noun: test, experiment');
     });
   });
 

--- a/src/shared/utils/text/markdown.js
+++ b/src/shared/utils/text/markdown.js
@@ -26,6 +26,49 @@ export class SimpleMarkdown {
   // Matches parenthesized RTL text at the start of a line (e.g., "(اسم)")
   static PARENTHESIZED_RTL_START = new RegExp(`^\\s*\\([${SimpleMarkdown.RTL_REGEX.source.slice(1, -1)}\\s]+\\)`);
 
+  static _isPronunciationGuideCandidate(text) {
+    if (!text || typeof text !== 'string') {
+      return false;
+    }
+
+    const normalized = text.trim();
+    if (!normalized || /\s/.test(normalized)) {
+      return false;
+    }
+
+    const hasNestedBrackets = normalized.includes('[') || normalized.includes(']');
+    // eslint-disable-next-line no-misleading-character-class -- intentionally groups adjacent phonetic ranges
+    const hasPhoneticMarks = /[\u00C0-\u024F\u0300-\u036F\u02B0-\u02FF\u0250-\u02AF]/.test(normalized);
+    const hasLatin = /[A-Za-z]/.test(normalized);
+    const hasPronunciationPunctuation = /[()'’.-]/.test(normalized);
+
+    return hasNestedBrackets || hasPhoneticMarks || (hasLatin && hasPronunciationPunctuation);
+  }
+
+  static stripPronunciationGuides(text) {
+    if (!text || typeof text !== 'string') {
+      return text;
+    }
+
+    return text
+      .split('\n')
+      .map((line) => {
+        const match = line.match(/^(.*?)(\s*\[((?:[^\]\n]|(?:\[[^\]\n]*\]))+)\])\s*$/);
+
+        if (!match) {
+          return line;
+        }
+
+        const guideText = match[3] || '';
+        if (!this._isPronunciationGuideCandidate(guideText)) {
+          return line;
+        }
+
+        return match[1].trimEnd();
+      })
+      .join('\n');
+  }
+
   static render(markdown, preferredDir = "auto", options = { enableLabelFormatting: true }) {
     if (!markdown || typeof markdown !== "string") {
       return "";
@@ -631,20 +674,24 @@ export class SimpleMarkdown {
       return "";
     }
 
-    return text
-      // Strip code blocks (```code```) - do this first to preserve content but remove markers
-      .replace(/```[\s\S]*?```/g, (match) => {
-        return match.replace(/^```\w*\n?/, "").replace(/\n?```$/, "");
-      })
-      // Strip markdown links [text](url) keeping only text
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    const pronunciationStripped = this.stripPronunciationGuides(
+      text
+        // Strip code blocks (```code```) - do this first to preserve content but remove markers
+        .replace(/```[\s\S]*?```/g, (match) => {
+          return match.replace(/^```\w*\n?/, "").replace(/\n?```$/, "");
+        })
+        // Strip markdown links [text](url) keeping only text
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    );
+
+    return pronunciationStripped
       // Strip pronunciation guides like [go(a)vāhi] or [n(y)o͞oz]
       // Matches brackets that are NOT followed by (url)
-      // Range includes: basic latin, latin extended, combining diacritics, and phonetic extensions
-      // NOTE: We disable no-misleading-character-class because we intentionally include 
-      // combining diacritics (\u0300-\u036F) to strip them from pronunciation guides.
+      // Range includes: basic latin, latin extended, combining diacritics, and phonetic extensions.
+      // We intentionally avoid whitespace here so non-pronunciation bracketed phrases like
+      // "[Chapter 1]" are preserved.
       // eslint-disable-next-line no-misleading-character-class
-      .replace(/\[[a-zA-Z0-9()\s'\u00C0-\u017F\u0300-\u036F\u02B0-\u02FF]+\](?!\()/g, "")
+      .replace(/\[[a-zA-Z0-9()'\u00C0-\u017F\u0300-\u036F\u02B0-\u02FF]+\](?!\()/g, "")
       // Strip headers (# header)
       .replace(/^#+\s?/gm, "")
       // Strip blockquotes (> quote)

--- a/src/shared/utils/text/markdown.test.js
+++ b/src/shared/utils/text/markdown.test.js
@@ -403,6 +403,7 @@ describe('SimpleMarkdown', () => {
       expect(SimpleMarkdown.strip('news [n(y)o͞oz]')).toBe('news');
       expect(SimpleMarkdown.strip('متعدد [mote(a)\'added]')).toBe('متعدد');
       expect(SimpleMarkdown.strip('word [phonetic] and more')).toBe('word  and more');
+      expect(SimpleMarkdown.strip("آزمایش ['āz[e]māyeš]")).toBe('آزمایش');
     });
 
     it('should handle mixed markdown', () => {
@@ -912,6 +913,11 @@ describe('SimpleMarkdown', () => {
       expect(SimpleMarkdown.strip(text)).toBe('گواهی');
     });
 
+    it('should strip Vajehyab nested-bracket pronunciation guides from clean text', () => {
+      const text = "آزمایش ['āz[e]māyeš]";
+      expect(SimpleMarkdown.strip(text)).toBe('آزمایش');
+    });
+
     it('should handle empty lines in input', () => {
       const text = '\n\n\nHello\n\n\nWorld\n\n\n';
       const result = SimpleMarkdown.getCleanTranslation(text);
@@ -922,6 +928,16 @@ describe('SimpleMarkdown', () => {
     it('should keep old history-shaped dictionary strings clean for primary extraction', () => {
       const input = 'translation\n\n**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test';
       expect(SimpleMarkdown.getCleanTranslation(input)).toBe('translation');
+    });
+
+    it('should remove Vajehyab nested-bracket pronunciation guides when extracting primary text', () => {
+      const input = "### آزمایش ['āz[e]māyeš]\n*اسم*\n\n---\n\n**معنی**:\nدرود";
+      expect(SimpleMarkdown.getCleanTranslation(input, ExtractionStrategy.PRIMARY_ONLY)).toBe('آزمایش');
+    });
+
+    it('should preserve meaningful bracketed content that is not a pronunciation guide', () => {
+      const input = 'Refer to [Chapter 1] for details';
+      expect(SimpleMarkdown.strip(input)).toBe('Refer to [Chapter 1] for details');
     });
 
     it('should handle malformed markdown', () => {

--- a/src/shared/utils/text/markdown.test.js
+++ b/src/shared/utils/text/markdown.test.js
@@ -82,6 +82,11 @@ describe('SimpleMarkdown', () => {
         expect(SimpleMarkdown.getCleanTranslation(input, ExtractionStrategy.PRIMARY_ONLY)).toBe('اخبار');
         expect(SimpleMarkdown.getCleanTranslation(input, ExtractionStrategy.FULL_TEXT)).toBe('اخباراسم: اخبار, خبر');
       });
+
+      it('should treat legacy one-line traditional provider output as primary translation only', () => {
+        const input = 'translation **Noun**: hello, hi';
+        expect(SimpleMarkdown.getCleanTranslation(input)).toBe('translation');
+      });
     });
 
     describe('Traditional Provider Format', () => {
@@ -647,7 +652,7 @@ describe('SimpleMarkdown', () => {
       expect(result.textContent).toContain('US: hi');
     });
 
-    it('should preprocess traditional one-line provider output', () => {
+    it('should preserve legacy one-line traditional provider triage behavior', () => {
       const result = SimpleMarkdown.render('translation **Noun**: hello, hi');
       expect(result).toBeTruthy();
 

--- a/src/shared/utils/text/markdown.test.js
+++ b/src/shared/utils/text/markdown.test.js
@@ -619,6 +619,42 @@ describe('SimpleMarkdown', () => {
       expect(result).toBeTruthy();
     });
 
+    it('should render plain label lines correctly', () => {
+      const result = SimpleMarkdown.render('Noun: test, experiment');
+      expect(result).toBeTruthy();
+
+      const strongTexts = Array.from(result.querySelectorAll('strong')).map((node) => node.textContent);
+      expect(strongTexts).toContain('Noun');
+      expect(result.textContent).toContain('test, experiment');
+    });
+
+    it('should render header-style labels correctly', () => {
+      const result = SimpleMarkdown.render('Definitions:\n- test');
+      expect(result).toBeTruthy();
+
+      const strongTexts = Array.from(result.querySelectorAll('strong')).map((node) => node.textContent);
+      expect(strongTexts).toContain('Definitions');
+      expect(result.textContent).toContain('Definitions: test');
+    });
+
+    it('should split multi-label same-line input', () => {
+      const result = SimpleMarkdown.render('**UK**: hello **US**: hi');
+      expect(result).toBeTruthy();
+
+      const strongTexts = Array.from(result.querySelectorAll('strong')).map((node) => node.textContent);
+      expect(strongTexts).toEqual(expect.arrayContaining(['UK', 'US']));
+      expect(result.textContent).toContain('UK: hello');
+      expect(result.textContent).toContain('US: hi');
+    });
+
+    it('should preprocess traditional one-line provider output', () => {
+      const result = SimpleMarkdown.render('translation **Noun**: hello, hi');
+      expect(result).toBeTruthy();
+
+      expect(result.querySelectorAll('strong').length).toBe(0);
+      expect(result.textContent).toBe('translation');
+    });
+
     it('should not treat bold text without a colon as a dictionary label', () => {
       const result = SimpleMarkdown.render('**Important** text without a colon');
       expect(result).toBeTruthy();
@@ -857,11 +893,30 @@ describe('SimpleMarkdown', () => {
       expect(result).toBe('کتاب');
     });
 
+    it('should preserve mixed-direction dictionary direction behavior', () => {
+      const rendered = SimpleMarkdown.render('Noun: آزمایش');
+      const paragraph = rendered.querySelector('p');
+      expect(paragraph).toBeTruthy();
+      expect(paragraph.getAttribute('dir')).toBe('rtl');
+      expect(rendered.textContent).toContain('Noun');
+      expect(rendered.textContent).toContain('آزمایش');
+    });
+
+    it('should strip pronunciation bracket guides from clean text', () => {
+      const text = 'گواهی [go(a)vāhi]';
+      expect(SimpleMarkdown.strip(text)).toBe('گواهی');
+    });
+
     it('should handle empty lines in input', () => {
       const text = '\n\n\nHello\n\n\nWorld\n\n\n';
       const result = SimpleMarkdown.getCleanTranslation(text);
       // Current implementation returns first non-empty line
       expect(result).toContain('Hello');
+    });
+
+    it('should keep old history-shaped dictionary strings clean for primary extraction', () => {
+      const input = 'translation\n\n**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test';
+      expect(SimpleMarkdown.getCleanTranslation(input)).toBe('translation');
     });
 
     it('should handle malformed markdown', () => {

--- a/src/shared/utils/text/markdownPreview.js
+++ b/src/shared/utils/text/markdownPreview.js
@@ -1,0 +1,225 @@
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+import { SimpleMarkdown } from "@/shared/utils/text/markdown.js";
+
+const LEGACY_PLAIN_LABEL_RE = /^[^:*#>`\-\s][^:]{0,80}:\s+\S+/;
+const RTL_CHAR_RE = /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/g;
+const NON_RTL_STRONG_CHAR_RE = /[a-zA-Z\u00C0-\u024F\u0370-\u03FF\u0400-\u04FF\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/g;
+
+const countMatches = (text, regex) => (text.match(regex) || []).length;
+
+const detectBlockDirection = (text, fallbackDir = "ltr") => {
+  if (!text || typeof text !== "string") {
+    return fallbackDir;
+  }
+
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return fallbackDir;
+  }
+
+  const labelSeparatorIndex = normalized.indexOf(":");
+  const hasLabelShape = labelSeparatorIndex > -1 && !normalized.includes("://");
+  const candidateText = hasLabelShape
+    ? normalized.slice(labelSeparatorIndex + 1).trim() || normalized
+    : normalized;
+
+  const rtlCount = countMatches(candidateText, RTL_CHAR_RE);
+  const ltrCount = countMatches(candidateText, NON_RTL_STRONG_CHAR_RE);
+
+  if (rtlCount === 0 && ltrCount === 0) {
+    return fallbackDir;
+  }
+
+  if (hasLabelShape && candidateText !== normalized) {
+    if (ltrCount > rtlCount) return "ltr";
+    if (rtlCount > ltrCount) return "rtl";
+    return fallbackDir;
+  }
+
+  if (ltrCount === 0) return "rtl";
+  if (rtlCount === 0) return "ltr";
+
+  if (ltrCount > rtlCount && (ltrCount - rtlCount >= 2 || ltrCount >= rtlCount * 1.5)) {
+    return "ltr";
+  }
+
+  if (rtlCount > ltrCount && (rtlCount - ltrCount >= 2 || rtlCount >= ltrCount * 1.5)) {
+    return "rtl";
+  }
+
+  if (/^[\u0590-\u08FF]/.test(normalized)) {
+    return fallbackDir;
+  }
+
+  if (/^[A-Za-z\u00C0-\u024F]/.test(normalized)) {
+    return "ltr";
+  }
+
+  return fallbackDir;
+};
+
+const applyBlockDirection = (element, fallbackDir) => {
+  if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+    return;
+  }
+
+  const direction = detectBlockDirection(element.textContent || "", fallbackDir);
+  element.setAttribute("dir", direction);
+};
+
+const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false, fallbackDir = "ltr") => {
+  if (!html || typeof html !== "string") {
+    return "";
+  }
+
+  const sanitizedHtml = DOMPurify.sanitize(html);
+  if (!sanitizedHtml) {
+    return "";
+  }
+
+  const container = document.createElement("div");
+  container.innerHTML = wrapWithSimpleMarkdown
+    ? `<div class="simple-markdown">${sanitizedHtml}</div>`
+    : sanitizedHtml;
+
+  const root = container.querySelector(".simple-markdown") || container.firstElementChild || container;
+
+  if (!root) {
+    return "";
+  }
+
+  root.querySelectorAll("p").forEach((paragraph) => {
+    const nextElement = paragraph.nextElementSibling;
+    const isLabelParagraph = (
+      paragraph.textContent?.trim().endsWith(":") &&
+      paragraph.querySelector("strong") &&
+      nextElement &&
+      ["UL", "OL"].includes(nextElement.tagName)
+    );
+
+    if (!isLabelParagraph) {
+      return;
+    }
+
+    const group = document.createElement("div");
+    group.className = "md-label-list-group";
+    paragraph.classList.add("md-label-paragraph");
+    nextElement.classList.add("md-label-list");
+
+    Array.from(nextElement.childNodes).forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE && !node.textContent.trim()) {
+        node.remove();
+      }
+    });
+
+    paragraph.parentNode.insertBefore(group, paragraph);
+    group.appendChild(paragraph);
+    group.appendChild(nextElement);
+  });
+
+  root
+    .querySelectorAll("p, h1, h2, h3, h4, h5, h6, blockquote, pre, ul, ol, li, .md-label-list-group, .md-label-paragraph, .md-label-list")
+    .forEach((element) => {
+      applyBlockDirection(element, fallbackDir);
+    });
+
+  root.querySelectorAll("a").forEach((link) => {
+    const href = (link.getAttribute("href") || "").trim();
+
+    if (!/^https?:\/\//i.test(href)) {
+      const textNode = document.createTextNode(link.textContent || "");
+      link.replaceWith(textNode);
+      return;
+    }
+
+    link.setAttribute("target", "_blank");
+    link.setAttribute("rel", "noopener noreferrer");
+  });
+
+  if (root.classList && !root.classList.contains("simple-markdown")) {
+    root.classList.add("simple-markdown");
+  }
+
+  return DOMPurify.sanitize(root.outerHTML, {
+    ADD_ATTR: ["target", "rel"],
+  });
+};
+
+export function renderMarkdownPreview(content, options = {}) {
+  const {
+    fallbackDir = "ltr",
+    isDictionary = false,
+    enableMarkdown = true,
+  } = options;
+
+  if (!content || typeof content !== "string") {
+    return "";
+  }
+
+  if (enableMarkdown) {
+    try {
+      if (shouldUseLegacySimpleMarkdown(content, isDictionary)) {
+        const markdownElement = SimpleMarkdown.render(content, fallbackDir, {
+          enableLabelFormatting: isDictionary,
+        });
+
+        if (markdownElement) {
+          return normalizeRenderedHtml(markdownElement.outerHTML, false, fallbackDir);
+        }
+
+        return normalizeRenderedHtml(content.replace(/\n/g, "<br>"), true, fallbackDir);
+      }
+
+      const markedHtml = marked.parse(content, {
+        gfm: true,
+        breaks: false,
+        mangle: false,
+      });
+
+      return normalizeRenderedHtml(markedHtml, true, fallbackDir);
+    } catch {
+      return normalizeRenderedHtml(content.replace(/\n/g, "<br>"), true, fallbackDir);
+    }
+  }
+
+  return normalizeRenderedHtml(content.replace(/\n/g, "<br>"), true, fallbackDir);
+}
+
+function shouldUseLegacySimpleMarkdown(content, isDictionary) {
+  const normalized = content.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  const lines = normalized.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (lines.length === 0) {
+    return false;
+  }
+
+  if (lines.length === 1) {
+    const line = lines[0];
+
+    const oneLineLabelMatch = line.match(/^(.*?)\*\*.*?\*\*.*:(?!\/\/)/);
+    if (oneLineLabelMatch && oneLineLabelMatch[1].trim().length > 0) {
+      return true;
+    }
+
+    const boldLabelMatches = line.match(/\*\*[^*]+?\*\*/g) || [];
+    if (boldLabelMatches.length > 1 && line.includes(':')) {
+      return true;
+    }
+
+    if (isDictionary && !line.includes('**') && LEGACY_PLAIN_LABEL_RE.test(line)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  if (isDictionary && !normalized.includes('**')) {
+    return lines.some((line) => LEGACY_PLAIN_LABEL_RE.test(line));
+  }
+
+  return false;
+}

--- a/src/shared/utils/text/markdownPreview.js
+++ b/src/shared/utils/text/markdownPreview.js
@@ -78,12 +78,16 @@ const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false, fallbackDir
     return "";
   }
 
-  const container = document.createElement("div");
-  container.innerHTML = wrapWithSimpleMarkdown
-    ? `<div class="simple-markdown">${sanitizedHtml}</div>`
-    : sanitizedHtml;
+  const parsedDocument = new DOMParser().parseFromString(
+    wrapWithSimpleMarkdown
+      ? `<div class="simple-markdown">${sanitizedHtml}</div>`
+      : sanitizedHtml,
+    "text/html",
+  );
 
-  const root = container.querySelector(".simple-markdown") || container.firstElementChild || container;
+  const root = parsedDocument.querySelector(".simple-markdown")
+    || parsedDocument.body.firstElementChild
+    || parsedDocument.body;
 
   if (!root) {
     return "";
@@ -141,7 +145,11 @@ const normalizeRenderedHtml = (html, wrapWithSimpleMarkdown = false, fallbackDir
     root.classList.add("simple-markdown");
   }
 
-  return DOMPurify.sanitize(root.outerHTML, {
+  const renderedHtml = root === parsedDocument.body
+    ? parsedDocument.body.innerHTML
+    : root.outerHTML;
+
+  return DOMPurify.sanitize(renderedHtml, {
     ADD_ATTR: ["target", "rel"],
   });
 };

--- a/src/utils/rendering/TranslationRenderer.test.js
+++ b/src/utils/rendering/TranslationRenderer.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTranslationRenderer } from './TranslationRenderer.js';
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('@/core/memory/ResourceTracker.js', () => ({
+  default: class MockResourceTracker {
+    addEventListener(target, eventName, handler) {
+      target.addEventListener(eventName, handler);
+    }
+  },
+}));
+
+describe('TranslationRenderer utility', () => {
+  let renderer;
+
+  const googleMarkdown = '**Noun**: test, experiment\n\n**Pronunciation**: /tɛst/\n\n**Definitions**:\n- (noun) a test\n\n**Examples**:\n- This is a test';
+  const vajehyabMarkdown = '### سلام [salām]\n*اسم*\n\n---\n\n**معنی (لغت‌نامه عمید)**:\nدرود، تحیت';
+  const legacyOneLine = 'translation **Noun**: hello, hi';
+  const unsafeHtml = '<img src=x onerror=alert(1)><script>alert(2)</script>';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    renderer = createTranslationRenderer({
+      enableMarkdown: true,
+      enableLabelFormatting: true,
+      mode: 'selection',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders normalized Google bold-label markdown through SimpleMarkdown DOM output', () => {
+    const element = renderer.createContentElement({
+      content: googleMarkdown,
+      error: null,
+      isLoading: false,
+      placeholder: '',
+    });
+
+    const markdownRoot = element.querySelector('.simple-markdown');
+
+    expect(element.className).toContain('translation-content');
+    expect(element.getAttribute('dir')).toBe('ltr');
+    expect(markdownRoot).not.toBeNull();
+    expect(markdownRoot.querySelector('strong').textContent).toBe('Noun');
+    expect(markdownRoot.textContent).toContain('Pronunciation');
+    expect(markdownRoot.querySelector('a')).toBeNull();
+  });
+
+  it('renders Vajehyab markdown-like output through SimpleMarkdown DOM output', () => {
+    const element = renderer.createContentElement({
+      content: vajehyabMarkdown,
+      error: null,
+      isLoading: false,
+      placeholder: '',
+    });
+
+    const markdownRoot = element.querySelector('.simple-markdown');
+
+    expect(markdownRoot).not.toBeNull();
+    expect(markdownRoot.querySelector('h3').textContent).toBe('سلام [salām]');
+    expect(markdownRoot.querySelector('em').textContent).toBe('اسم');
+    expect(markdownRoot.querySelector('strong').textContent).toBe('معنی (لغت‌نامه عمید)');
+  });
+
+  it('preserves legacy one-line provider triage behavior', () => {
+    const element = renderer.createContentElement({
+      content: legacyOneLine,
+      error: null,
+      isLoading: false,
+      placeholder: '',
+    });
+
+    const markdownRoot = element.querySelector('.simple-markdown');
+
+    expect(markdownRoot).not.toBeNull();
+    expect(markdownRoot.textContent).toBe('translation');
+    expect(markdownRoot.textContent).not.toContain('Noun');
+  });
+
+  it('does not insert raw HTML as active DOM', () => {
+    const element = renderer.createContentElement({
+      content: unsafeHtml,
+      error: null,
+      isLoading: false,
+      placeholder: '',
+    });
+
+    expect(element.querySelector('[onerror]')).toBeNull();
+    expect(element.querySelector('script')).toBeNull();
+    expect(element.innerHTML).not.toContain('onerror');
+    expect(element.innerHTML).not.toContain('<script>');
+    expect(element.textContent).not.toContain('alert(1)');
+    expect(element.textContent).not.toContain('alert(2)');
+  });
+
+  it('keeps safe links with target blank and noopener noreferrer through SimpleMarkdown', () => {
+    const element = renderer.createContentElement({
+      content: '[Click](https://example.com)',
+      error: null,
+      isLoading: false,
+      placeholder: '',
+    });
+
+    const link = element.querySelector('a');
+
+    expect(link).not.toBeNull();
+    expect(link.getAttribute('href')).toBe('https://example.com');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+});


### PR DESCRIPTION
This PR introduces a unified markdown rendering pipeline across translation displays and history views. It centralizes markdown preview generation, improves dictionary rendering for Google and Vajehyab outputs, restores mixed RTL/LTR behavior, and expands characterization test coverage.

### Key Changes

#### Markdown Rendering
- Introduced a shared `renderMarkdownPreview()` pipeline for markdown parsing, sanitization, DOM normalization, and direction handling.
- Added `SafeMarkdownPreview` as the single controlled HTML rendering boundary.
- Centralized markdown rendering behavior across TranslationDisplay, Sidepanel History, and Mobile History views.

#### History Improvements
- Added markdown preview support for translated entries in sidepanel and mobile history.
- Preserved existing storage and export formats while improving on-screen rendering.

#### Dictionary Formatting
- Improved Google Dictionary rendering, including compact label/list grouping for Definitions and Examples sections.
- Improved Vajehyab markdown handling and pronunciation rendering consistency.
- Restored per-block RTL/LTR direction detection for mixed-language dictionary content.

#### TTS & Text Extraction
- Improved shared text extraction logic used by TTS and copy workflows.
- Added support for cleaning Vajehyab pronunciation guides from extracted speech text while preserving display output.

#### Styling & UX
- Added theme-aware markdown code styling for light and dark themes.
- Improved spacing, list rendering, and markdown presentation consistency across UI surfaces.

#### Testing
- Added extensive characterization coverage for:
  - markdown rendering
  - history previews
  - dictionary formatting
  - pronunciation/IPA rendering
  - provider-specific markdown output
  - TTS extraction behavior

### Notes

- Legacy SimpleMarkdown fallback behavior is preserved for backward compatibility.
- History storage, exports (JSON/CSV/Anki), and provider contracts remain unchanged.

Closes #140