### PR TITLE
tune(optimization): improve base-2 concurrency scaling

### DIFF
--- a/src/features/translation/core/ProviderConfigurations.js
+++ b/src/features/translation/core/ProviderConfigurations.js
@@ -966,18 +966,34 @@ function applyOptimizationLevel(config, level) {
   const aiSizeMultipliers = { 1: 2.5, 2: 1.5, 3: 1, 4: 0.6, 5: 0.3 };
   const sizeMultipliers = { 1: 1.5, 2: 1.2, 3: 1, 4: 0.8, 5: 0.6 };
 
+  // Base-2 providers need a visible step-up at Level 2 so low and medium
+  // optimization modes are not concurrency-identical. Larger base values keep
+  // the standard multiplier curve.
+  const scaleConcurrentLimit = (baseConcurrent, levelValue) => {
+    if (baseConcurrent === 2) {
+      const baseTwoCurve = { 1: 1, 2: 2, 3: 2, 4: 3, 5: 4 };
+      return baseTwoCurve[levelValue];
+    }
+
+    if (levelValue < 3) {
+      return Math.max(1, Math.floor(baseConcurrent * concurrentMultipliers[levelValue]));
+    }
+
+    if (levelValue > 3) {
+      return Math.max(baseConcurrent, Math.ceil(baseConcurrent * concurrentMultipliers[levelValue]));
+    }
+
+    return baseConcurrent;
+  };
+
   // 1. Scale Rate Limits
   // Concurrent requests multipliers: Level 1 (0.4), Level 2 (0.7), Level 3 (1.0), Level 4 (1.5), Level 5 (2.0)
-  // We use floor for levels < 3 to be more conservative and ceil for levels > 3 to be more aggressive
+  // We use floor for levels < 3 to be more conservative and ceil for levels > 3 to be more aggressive.
+  // Base-2 providers use a dedicated curve so Level 2 can be distinct from Level 1.
   const baseConcurrent = config.rateLimit.maxConcurrent;
-  
-  if (safeLevel < 3) {
-    result.rateLimit.maxConcurrent = Math.max(1, Math.floor(baseConcurrent * concurrentMultipliers[safeLevel]));
-  } else if (safeLevel > 3) {
-    result.rateLimit.maxConcurrent = Math.max(baseConcurrent, Math.ceil(baseConcurrent * concurrentMultipliers[safeLevel]));
-  }
+  result.rateLimit.maxConcurrent = scaleConcurrentLimit(baseConcurrent, safeLevel);
 
-  // Scale Burst Limit if it exists, using the same logic
+  // Scale Burst Limit if it exists, using the original conservative curve.
   if (config.rateLimit.burstLimit) {
     const baseBurst = config.rateLimit.burstLimit;
     if (safeLevel < 3) {
@@ -1053,12 +1069,7 @@ function applyOptimizationLevel(config, level) {
       const modeConfig = { ...config.rateLimit.modeOverrides[mode] };
       
       if (modeConfig.maxConcurrent) {
-        if (safeLevel < 3) {
-          modeConfig.maxConcurrent = Math.max(1, Math.floor(modeConfig.maxConcurrent * concurrentMultipliers[safeLevel]));
-        } else if (safeLevel > 3) {
-          modeConfig.maxConcurrent = Math.max(modeConfig.maxConcurrent, Math.ceil(modeConfig.maxConcurrent * concurrentMultipliers[safeLevel]));
-        }
-        modeConfig.maxConcurrent = Math.min(modeConfig.maxConcurrent, 12);
+        modeConfig.maxConcurrent = Math.min(scaleConcurrentLimit(modeConfig.maxConcurrent, safeLevel), 12);
       }
       
       if (modeConfig.burstLimit) {

--- a/src/features/translation/core/ProviderConfigurations.test.js
+++ b/src/features/translation/core/ProviderConfigurations.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+import { PROVIDER_CONFIGURATIONS, getProviderRateLimit } from './ProviderConfigurations.js';
+
+describe('ProviderConfigurations optimization scaling', () => {
+  it('should give base-2 providers a distinct Level 2 concurrency step', () => {
+    const levels = [1, 2, 3, 4, 5];
+    const expected = [1, 2, 2, 3, 4];
+
+    for (const providerName of ['WebAI', 'OpenAI', 'DeepSeek', 'OpenRouter', 'Custom']) {
+      const actual = levels.map(level => getProviderRateLimit(providerName, level).maxConcurrent);
+      expect(actual).toEqual(expected);
+    }
+  });
+
+  it('should keep base-1 providers on the conservative matrix', () => {
+    const levels = [1, 2, 3, 4, 5];
+    const expected = [1, 1, 1, 2, 2];
+    const originalMaxConcurrent = PROVIDER_CONFIGURATIONS.Custom.rateLimit.maxConcurrent;
+
+    try {
+      PROVIDER_CONFIGURATIONS.Custom.rateLimit.maxConcurrent = 1;
+
+      expect(levels.map(level => getProviderRateLimit('Custom', level).maxConcurrent))
+        .toEqual(expected);
+    } finally {
+      PROVIDER_CONFIGURATIONS.Custom.rateLimit.maxConcurrent = originalMaxConcurrent;
+    }
+  });
+
+  it('should keep higher-base providers on sensible growth curves', () => {
+    expect([1, 2, 3, 4, 5].map(level => getProviderRateLimit('Gemini', level).maxConcurrent))
+      .toEqual([1, 2, 3, 5, 6]);
+
+    expect([1, 2, 3, 4, 5].map(level => getProviderRateLimit('GoogleTranslate', level).maxConcurrent))
+      .toEqual([1, 2, 4, 6, 8]);
+
+    expect([1, 2, 3, 4, 5].map(level => getProviderRateLimit('DeepLTranslate', level).maxConcurrent))
+      .toEqual([2, 3, 5, 8, 10]);
+  });
+
+  it('should keep WebAI aligned with the desired base-2 curve', () => {
+    expect(getProviderRateLimit('WebAI', 2).maxConcurrent).toBe(2);
+    expect(getProviderRateLimit('WebAI', 5).maxConcurrent).toBe(4);
+  });
+
+  it('should scale select element mode overrides for base-2 providers', () => {
+    const levels = [1, 2, 3, 4, 5];
+    const expected = [1, 2, 2, 3, 4];
+
+    expect(levels.map(level => getProviderRateLimit('WebAI', level).modeOverrides.select_element.maxConcurrent))
+      .toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Tuned optimization scaling so base-2 providers now get a distinct Level 2 concurrency step while keeping Level 1 conservative and preserving the existing curve for higher-base providers.

## Changes

* Adjusted optimization scaling for providers with base `maxConcurrent = 2`.
* Kept delay scaling unchanged.
* Kept burst scaling unchanged.
* Preserved higher-base provider scaling behavior.
* Added regression tests for base-1 and base-2 matrix expectations.
* Added coverage for Select Element mode override scaling shape.

## Architecture Notes

* Base-2 providers now scale to L1=1, L2=2, L3=2, L4=3, L5=4.
* Other providers continue to use the existing multiplier curve.
* Delay scaling remains unchanged.
* Burst scaling remains unchanged.
* `rateLimit.modeOverrides.maxConcurrent` now uses the same helper curve for internal consistency.

## Validation

* Ran:

```text
pnpm exec vitest run --config tests/vitest.config.js src/features/translation/core/ProviderConfigurations.test.js --reporter=dot
```

* Result: 1 test file passed, 5 tests passed.
* Verified the provider configuration matrix passes.
* Verified the new regression assertions for base-1 and base-2 scaling pass.
* Verified Select Element mode override scaling shape.

## Risk Assessment

Regression risk is low because this is a config-only tuning change. It does not alter execution flow, queue behavior, cancellation handling, or provider orchestration.

One intentional behavioral impact: any flow that consumes provider `rateLimit.maxConcurrent` will receive the new base-2 scaling curve. This includes Page Translation for base-2 providers, even though no Page Translation code was changed.

## Notes

* QueueManager is unchanged.
* RateLimitManager is unchanged.
* Select Element execution lanes are unchanged.
* Page Translation code is unchanged, but its effective concurrency may change for base-2 providers because it consumes shared provider rate-limit configuration.
