### PR TITLE
fix(webai): restrict history support to Select Element

### DIFF
--- a/src/features/translation/providers/WebAI.js
+++ b/src/features/translation/providers/WebAI.js
@@ -3,6 +3,8 @@ import { BaseAIProvider } from "@/features/translation/providers/BaseAIProvider.
 import {
   getWebAIApiUrlAsync,
   getWebAIApiModelAsync,
+  getAIConversationHistoryEnabledAsync,
+  TranslationMode
 } from "@/shared/config/config.js";
 import { getScopedLogger } from '@/shared/logging/logger.js';
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';
@@ -36,12 +38,27 @@ export class WebAIProvider extends BaseAIProvider {
 
     this._validateConfig({ apiUrl, apiModel }, ["apiUrl", "apiModel"], `${this.providerName.toLowerCase()}-translation`);
 
-    const turnNumber = await AIConversationHelper.claimNextTurn(sessionId, this.providerName);
-    logger.info(`[WebAI] Model: ${apiModel}${sessionId ? ` (Session: ${sessionId.substring(0, 15)}..., Turn: ${turnNumber})` : ''}`);
+    const historyEnabled = await getAIConversationHistoryEnabledAsync();
+    const shouldUseConversationHistory =
+      historyEnabled && options.mode === TranslationMode.Select_Element;
+
+    const turnNumber = shouldUseConversationHistory
+      ? await AIConversationHelper.claimNextTurn(sessionId, this.providerName)
+      : null;
+    logger.info(`[WebAI] Model: ${apiModel}${sessionId ? ` (Session: ${sessionId.substring(0, 15)}...${turnNumber ? `, Turn: ${turnNumber}` : ''})` : ''}`);
 
     // WebAI uses a single prompt string instead of separate messages
     // We combine the system prompt and user text into a final message
-    const finalMessage = `${systemPrompt}\n\nText to translate:\n${userText}`;
+    const historyContext = shouldUseConversationHistory
+      ? await AIConversationHelper.formatCompactHistoryContext(sessionId, options.mode, {
+          maxChars: 300
+        })
+      : '';
+
+    const finalMessage = [
+      systemPrompt,
+      historyContext
+    ].filter(Boolean).join('\n\n') + `\n\nText to translate:\n${userText}`;
 
     const fetchOptions = {
       method: "POST",
@@ -69,7 +86,7 @@ export class WebAIProvider extends BaseAIProvider {
       sessionId
     });
 
-    if (sessionId && result) {
+    if (shouldUseConversationHistory && sessionId && result) {
       await AIConversationHelper.updateSessionHistory(sessionId, userText, result);
     }
     

--- a/src/features/translation/providers/WebAI.test.js
+++ b/src/features/translation/providers/WebAI.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ResponseFormat } from '@/shared/config/translationConstants.js';
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: { getBrowserInfo: vi.fn(), getManifest: () => ({ version: '1.0.0' }) },
+    storage: { local: { get: vi.fn(), set: vi.fn() } }
+  }
+}));
+
+vi.mock('@/shared/config/config.js', () => ({
+  getWebAIApiUrlAsync: vi.fn().mockResolvedValue('https://webai.example/api'),
+  getWebAIApiModelAsync: vi.fn().mockResolvedValue('webai-model'),
+  getAIConversationHistoryEnabledAsync: vi.fn().mockResolvedValue(true),
+  getSettingsAsync: vi.fn().mockResolvedValue({}),
+  getProviderOptimizationLevelAsync: vi.fn().mockResolvedValue(3),
+  TranslationMode: {
+    Select_Element: 'select-element'
+  }
+}));
+
+vi.mock('@/shared/proxy/ProxyManager.js', () => ({
+  proxyManager: {
+    fetch: vi.fn(),
+    setConfig: vi.fn(),
+    testConnection: vi.fn()
+  }
+}));
+
+vi.mock('./utils/AIConversationHelper.js', () => ({
+  AIConversationHelper: {
+    claimNextTurn: vi.fn().mockResolvedValue(7),
+    formatCompactHistoryContext: vi.fn().mockResolvedValue('Previous translation context:\nOriginal:\nPrevious original text\n\nTranslated:\nPrevious translated text'),
+    updateSessionHistory: vi.fn().mockResolvedValue(true)
+  }
+}));
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    init: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debugLazy: vi.fn()
+  })
+}));
+
+vi.mock('@/shared/messaging/core/MessagingCore.js', () => ({}));
+
+vi.mock('@/features/translation/core/ProviderCoordinator.js', () => ({
+  providerCoordinator: {
+    execute: vi.fn()
+  }
+}));
+
+import { WebAIProvider } from './WebAI.js';
+import { AIConversationHelper } from './utils/AIConversationHelper.js';
+import { getAIConversationHistoryEnabledAsync } from '@/shared/config/config.js';
+
+describe('WebAIProvider history support', () => {
+  let provider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new WebAIProvider();
+  });
+
+  it('injects compact Select Element history and keeps a single message payload when history is enabled', async () => {
+    getAIConversationHistoryEnabledAsync.mockResolvedValue(true);
+
+    let capturedRequest = null;
+    vi.spyOn(provider, '_executeRequest').mockImplementation(async (params) => {
+      capturedRequest = params;
+      return 'translated';
+    });
+
+    const result = await provider._callAI(
+      'System prompt',
+      'Current text',
+      {
+        sessionId: 'session-1',
+        mode: 'select-element',
+        expectedFormat: ResponseFormat.JSON_OBJECT,
+        isBatch: false
+      }
+    );
+
+    expect(result).toBe('translated');
+    expect(AIConversationHelper.claimNextTurn).toHaveBeenCalledWith('session-1', 'WebAI');
+    expect(AIConversationHelper.formatCompactHistoryContext).toHaveBeenCalledWith('session-1', 'select-element', { maxChars: 300 });
+    expect(AIConversationHelper.updateSessionHistory).toHaveBeenCalledWith('session-1', 'Current text', 'translated');
+
+    const body = JSON.parse(capturedRequest.fetchOptions.body);
+    expect(body).toEqual(expect.objectContaining({
+      message: expect.any(String),
+      model: 'webai-model',
+      response_format: { type: 'json_object' }
+    }));
+    expect(body).not.toHaveProperty('messages');
+    expect(body.message).toContain('System prompt');
+    expect(body.message).toContain('Previous translation context:');
+    expect(body.message).toContain('Previous original text');
+    expect(body.message).toContain('Previous translated text');
+    expect(body.message).toContain('Text to translate:');
+    expect(body.message).toContain('Current text');
+  });
+
+  it('remains stateless when history is disabled', async () => {
+    getAIConversationHistoryEnabledAsync.mockResolvedValue(false);
+
+    let capturedRequest = null;
+    vi.spyOn(provider, '_executeRequest').mockImplementation(async (params) => {
+      capturedRequest = params;
+      return 'translated';
+    });
+
+    await provider._callAI(
+      'System prompt',
+      'Current text',
+      {
+        sessionId: 'session-2',
+        mode: 'select-element',
+        expectedFormat: ResponseFormat.STRING,
+        isBatch: false
+      }
+    );
+
+    expect(AIConversationHelper.claimNextTurn).not.toHaveBeenCalled();
+    expect(AIConversationHelper.formatCompactHistoryContext).not.toHaveBeenCalled();
+    expect(AIConversationHelper.updateSessionHistory).not.toHaveBeenCalled();
+
+    const body = JSON.parse(capturedRequest.fetchOptions.body);
+    expect(body.message).toBe('System prompt\n\nText to translate:\nCurrent text');
+    expect(body).not.toHaveProperty('messages');
+  });
+
+  it('does not consume or store history for non-Select Element modes', async () => {
+    getAIConversationHistoryEnabledAsync.mockResolvedValue(true);
+
+    let capturedRequest = null;
+    vi.spyOn(provider, '_executeRequest').mockImplementation(async (params) => {
+      capturedRequest = params;
+      return 'translated';
+    });
+
+    await provider._callAI(
+      'System prompt',
+      'Current text',
+      {
+        sessionId: 'session-3',
+        mode: 'content',
+        expectedFormat: ResponseFormat.STRING,
+        isBatch: false
+      }
+    );
+
+    expect(AIConversationHelper.claimNextTurn).not.toHaveBeenCalled();
+    expect(AIConversationHelper.formatCompactHistoryContext).not.toHaveBeenCalled();
+    expect(AIConversationHelper.updateSessionHistory).not.toHaveBeenCalled();
+
+    const body = JSON.parse(capturedRequest.fetchOptions.body);
+    expect(body.message).toBe('System prompt\n\nText to translate:\nCurrent text');
+    expect(body.message).not.toContain('Previous translation context:');
+  });
+});

--- a/src/features/translation/providers/utils/AIConversationHelper.js
+++ b/src/features/translation/providers/utils/AIConversationHelper.js
@@ -165,6 +165,31 @@ export const AIConversationHelper = {
   },
 
   /**
+   * Format the last Select Element turn as compact prompt context.
+   * Returns an empty string when history is disabled or unavailable.
+   */
+  async formatCompactHistoryContext(sessionId, translateMode = '', options = {}) {
+    const turns = await this.getConversationHistory(sessionId, translateMode, {
+      maxTurns: 1,
+      maxChars: options.maxChars ?? TRANSLATION_CONSTANTS.HISTORY_CHARACTER_LIMITS.AI
+    });
+
+    if (!turns.length) return '';
+
+    const lastTurn = turns[turns.length - 1];
+    if (!lastTurn?.user || !lastTurn?.assistant) return '';
+
+    return [
+      'Previous translation context:',
+      'Original:',
+      lastTurn.user,
+      '',
+      'Translated:',
+      lastTurn.assistant
+    ].join('\n');
+  },
+
+  /**
    * Prepares a compact context string for DeepL
    */
   async prepareDeepLContext(sessionId, contextMetadata, translateMode = null) {

--- a/src/features/translation/providers/utils/AIConversationHelper.test.js
+++ b/src/features/translation/providers/utils/AIConversationHelper.test.js
@@ -38,10 +38,12 @@ vi.mock('@/features/translation/utils/bilingualPromptHelper.js', () => ({
 }));
 
 import { AIConversationHelper } from './AIConversationHelper.js';
+import { translationSessionManager } from '@/features/translation/core/TranslationSessionManager.js';
 
 describe('AIConversationHelper', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    translationSessionManager.sessions.clear();
   });
 
   it('uses the non-auto batch prompt when bilingual auto prompts are disabled', async () => {
@@ -114,5 +116,66 @@ describe('AIConversationHelper', () => {
     expect(occurrences).toBe(1);
     expect(systemPrompt).toContain('USER RULE ');
     expect(systemPrompt).toContain('BATCH RULE ');
+  });
+
+  it('formats compact Select Element history from the active session only', async () => {
+    const { getAIConversationHistoryEnabledAsync, TranslationMode } = await import('@/shared/config/config.js');
+    getAIConversationHistoryEnabledAsync.mockResolvedValue(true);
+
+    const activeSessionId = 'session-active';
+    const otherSessionId = 'session-other';
+
+    translationSessionManager.sessions.set(activeSessionId, {
+      id: activeSessionId,
+      provider: 'WebAI',
+      history: [
+        { role: 'user', content: 'Previous original text' },
+        { role: 'assistant', content: 'Previous translated text' }
+      ]
+    });
+
+    translationSessionManager.sessions.set(otherSessionId, {
+      id: otherSessionId,
+      provider: 'WebAI',
+      history: [
+        { role: 'user', content: 'Wrong session original' },
+        { role: 'assistant', content: 'Wrong session translated' }
+      ]
+    });
+
+    const context = await AIConversationHelper.formatCompactHistoryContext(activeSessionId, TranslationMode.Select_Element);
+
+    expect(context).toContain('Previous translation context:');
+    expect(context).toContain('Original:');
+    expect(context).toContain('Previous original text');
+    expect(context).toContain('Translated:');
+    expect(context).toContain('Previous translated text');
+    expect(context).not.toContain('Wrong session original');
+    expect(context).not.toContain('Wrong session translated');
+  });
+
+  it('returns an empty context when history is disabled or mode is not Select Element', async () => {
+    const { getAIConversationHistoryEnabledAsync, TranslationMode } = await import('@/shared/config/config.js');
+
+    getAIConversationHistoryEnabledAsync.mockResolvedValue(false);
+
+    translationSessionManager.sessions.set('session-id', {
+      id: 'session-id',
+      provider: 'WebAI',
+      history: [
+        { role: 'user', content: 'Previous original text' },
+        { role: 'assistant', content: 'Previous translated text' }
+      ]
+    });
+
+    await expect(
+      AIConversationHelper.formatCompactHistoryContext('session-id', TranslationMode.Select_Element)
+    ).resolves.toBe('');
+
+    getAIConversationHistoryEnabledAsync.mockResolvedValue(true);
+
+    await expect(
+      AIConversationHelper.formatCompactHistoryContext('session-id', TranslationMode.Field)
+    ).resolves.toBe('');
   });
 });


### PR DESCRIPTION
## Summary
Restrict WebAI conversation-history behavior to Select Element mode only and keep non-Select flows fully stateless with respect to AI session history.

## Changes
- Gate claimNextTurn() behind:
  - history enabled
  - TranslationMode.Select_Element
- Gate compact history injection behind:
  - history enabled
  - TranslationMode.Select_Element
- Gate updateSessionHistory() behind:
  - history enabled
  - TranslationMode.Select_Element
- Preserve single-message WebAI request format.
- Keep history-disabled behavior fully stateless.

## Tests
- Added coverage for Select Element history usage.
- Added coverage ensuring non-Select modes:
  - do not claim turns
  - do not read history
  - do not write history
- Added coverage ensuring history-disabled Select Element remains stateless.

## Result
- WebAI history support now matches the intended architecture:
  - Select Element: optional conversation continuity
  - Dictionary / Sidepanel / other modes: no AI session history usage