### PR TITLE
fix(mouse-hover): clear container highlight on translation errors

### DIFF
--- a/src/features/mouse-hover/HoverTranslationManager.js
+++ b/src/features/mouse-hover/HoverTranslationManager.js
@@ -230,6 +230,16 @@ export class HoverTranslationManager extends ResourceTracker {
   }
 
   /**
+   * Clean up the active hover state only if the request belongs to the current messageId.
+   * @private
+   */
+  _cleanupActiveHoverRequest(messageId) {
+    if (this.currentMessageId === messageId) {
+      this._handleMouseOut();
+    }
+  }
+
+  /**
    * Remove the visual border from the current element
    * @private
    */
@@ -395,8 +405,8 @@ export class HoverTranslationManager extends ResourceTracker {
       }
     } catch (error) {
       if (ExtensionContextManager.isContextError(error)) {
-        if (this.currentMessageId === messageId) this.currentMessageId = null;
         logger.debug('Hover translation skipped: Extension context invalidated');
+        this._cleanupActiveHoverRequest(messageId);
         return;
       }
 
@@ -408,10 +418,6 @@ export class HoverTranslationManager extends ResourceTracker {
         return;
       }
 
-      if (this.currentMessageId === messageId) {
-        this.currentMessageId = null;
-      }
-
       // Standard error handling via the Golden Chain architecture
       ErrorHandler.getInstance().handle(error, {
         context: 'hover',
@@ -419,6 +425,7 @@ export class HoverTranslationManager extends ResourceTracker {
       }).catch(() => {});
 
       this._emitPageEvent('MOUSE_HOVER_TRANSLATION_ERROR', { error });
+      this._cleanupActiveHoverRequest(messageId);
     }
   }
 

--- a/src/features/mouse-hover/HoverTranslationManager.test.js
+++ b/src/features/mouse-hover/HoverTranslationManager.test.js
@@ -228,5 +228,122 @@ describe('HoverTranslationManager', () => {
         direction: 'rtl'
       }));
     });
+
+    it('should clean up highlight and caches on context invalidation error', async () => {
+      await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_SCOPE') return 'container';
+        if (key === 'MOUSE_HOVER_SHOW_CONTAINER_BORDER') return true;
+        return def;
+      });
+
+      const element = document.createElement('div');
+      HoverTextDetector.detect.mockReturnValue({
+        text: 'Hello world',
+        rect: { top: 10, left: 10, bottom: 20, right: 100 },
+        element: element
+      });
+
+      contentScriptIntegration.sendTranslationRequest.mockRejectedValue(
+        new Error('Extension context invalidated')
+      );
+
+      await manager._processHover({ clientX: 15, clientY: 15 });
+
+      expect(element.classList.contains('ti-hover-container-highlight')).toBe(false);
+      expect(manager.borderedElement).toBeNull();
+      expect(manager.currentRect).toBeNull();
+      expect(manager.currentText).toBeNull();
+      expect(manager.currentElement).toBeNull();
+    });
+
+    it('should clean up highlight and caches on standard translation error', async () => {
+      await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_SCOPE') return 'container';
+        if (key === 'MOUSE_HOVER_SHOW_CONTAINER_BORDER') return true;
+        return def;
+      });
+
+      const element = document.createElement('div');
+      HoverTextDetector.detect.mockReturnValue({
+        text: 'Hello world',
+        rect: { top: 10, left: 10, bottom: 20, right: 100 },
+        element: element
+      });
+
+      contentScriptIntegration.sendTranslationRequest.mockRejectedValue(
+        new Error('Translation failed')
+      );
+
+      await manager._processHover({ clientX: 15, clientY: 15 });
+
+      expect(element.classList.contains('ti-hover-container-highlight')).toBe(false);
+      expect(manager.borderedElement).toBeNull();
+      expect(manager.currentRect).toBeNull();
+      expect(manager.currentText).toBeNull();
+      expect(manager.currentElement).toBeNull();
+    });
+
+    it('should not clean up highlight or caches if a stale failed request finishes after a new hover started', async () => {
+      await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_SCOPE') return 'container';
+        if (key === 'MOUSE_HOVER_SHOW_CONTAINER_BORDER') return true;
+        return def;
+      });
+
+      const element1 = document.createElement('div');
+      const element2 = document.createElement('div');
+
+      // 1. First hover starts
+      manager.currentElement = element1;
+      HoverTextDetector.detect.mockReturnValue({
+        text: 'Text one',
+        rect: { top: 10, left: 10, bottom: 20, right: 100 },
+        element: element1
+      });
+
+      let rejectRequest1;
+      const promise1 = new Promise((_, reject) => {
+        rejectRequest1 = () => reject(new Error('Extension context invalidated'));
+      });
+      contentScriptIntegration.sendTranslationRequest.mockReturnValueOnce(promise1);
+
+      const processPromise1 = manager._processHover({ clientX: 15, clientY: 15 });
+      const firstMessageId = manager.currentMessageId;
+
+      expect(element1.classList.contains('ti-hover-container-highlight')).toBe(true);
+      expect(manager.currentText).toBe('Text one');
+
+      // 2. Second hover starts before first completes, overriding active hover state
+      manager.currentElement = element2;
+      HoverTextDetector.detect.mockReturnValue({
+        text: 'Text two',
+        rect: { top: 20, left: 20, bottom: 30, right: 120 },
+        element: element2
+      });
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        translatedText: 'Translation two',
+        direction: 'ltr'
+      });
+
+      await manager._processHover({ clientX: 25, clientY: 25 });
+      const secondMessageId = manager.currentMessageId;
+
+      expect(secondMessageId).not.toBe(firstMessageId);
+      expect(element2.classList.contains('ti-hover-container-highlight')).toBe(true);
+      expect(manager.currentText).toBe('Text two');
+
+      // 3. First request fails (e.g. throws context error)
+      rejectRequest1();
+      await processPromise1;
+
+      // 4. Verify stale first request's failure did NOT clear the second hover's state
+      expect(element2.classList.contains('ti-hover-container-highlight')).toBe(true);
+      expect(manager.currentText).toBe('Text two');
+      expect(manager.currentElement).toBe(element2);
+      expect(manager.borderedElement).toBe(element2);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes an issue in Mouse Hover container mode where the container highlight border could remain visible after translation failures, causing the UI to appear stuck in a loading state.

## Changes

* Added centralized hover-request cleanup via `_cleanupActiveHoverRequest(messageId)`.
* Clear active hover state when a translation fails due to:

  * Extension context invalidation
  * Standard translation/provider errors
* Preserve race-safety by only cleaning up when the failed request still owns the active `messageId`.
* Keep intentional cancellation behavior unchanged.

## Tests

Added coverage for:

* Context invalidation cleanup removes the container highlight.
* Standard translation error cleanup removes the container highlight.
* Cleanup clears hover caches and active hover state.
* Stale failed requests do not clear the state of a newer active hover request.

All related tests pass.
