### PR TITLE
fix(content): stop leaking extracted content CSS into page scope

### DIFF
--- a/config/vite/vite.config.chrome.js
+++ b/config/vite/vite.config.chrome.js
@@ -269,6 +269,14 @@ export default defineConfig({
         }
       },
       transformManifest: async (manifest) => {
+        // Prevent Vite from injecting extracted content UI CSS into page scope.
+        // Content UI styles are loaded manually into the ShadowRoot.        
+        for (const contentScript of manifest.content_scripts || []) {
+          if (contentScript.js?.includes('src/core/content-scripts/index-main.js')) {
+            delete contentScript.css;
+          }
+        }
+
         const outDir = baseOutDir;
         await fs.ensureDir(outDir);
         await fs.ensureDir(resolve(outDir, 'src/html'));

--- a/config/vite/vite.config.firefox.js
+++ b/config/vite/vite.config.firefox.js
@@ -133,6 +133,14 @@ export default defineConfig({
 
       // Write generated manifest.json to disk for dev mode to enable extension auto-install
       transformManifest: async (manifest) => {
+        // Prevent Vite from injecting extracted content UI CSS into page scope.
+        // Content UI styles are loaded manually into the ShadowRoot.
+        for (const contentScript of manifest.content_scripts || []) {
+          if (contentScript.js?.includes('src/core/content-scripts/index-main.js')) {
+            delete contentScript.css;
+          }
+        }
+
         const outDir = baseOutDir;
         await fs.ensureDir(outDir);
         await fs.ensureDir(resolve(outDir, 'src/html'));

--- a/docs/technical/VITE_BUILD_SYSTEM.md
+++ b/docs/technical/VITE_BUILD_SYSTEM.md
@@ -29,6 +29,36 @@ The project maintains three core configurations under `config/vite/`:
 
 ---
 
+## 1.1. Content Script CSS Ownership
+
+The content UI is rendered entirely inside a Shadow DOM.
+
+To preserve Shadow DOM isolation, Content UI styles are injected manually
+into the ShadowRoot at runtime.
+
+Although Vite extracts component SCSS into CSS assets, the auto-generated
+CSS for the main content script is intentionally removed from the final
+manifest during `transformManifest()`. Otherwise, the browser would inject
+those styles into the host page through `manifest.content_scripts[].css`,
+bypassing Shadow DOM isolation.
+
+This results in a clear ownership model:
+
+- **Content UI styles** → ShadowRoot only.
+- **Page-facing styles** (Element Selection, Mouse Hover, Page Translation
+  layout fixes, iframe highlights, etc.) → Explicit page-style injection.
+
+### Design Rule
+
+Never rely on `manifest.content_scripts[].css` for Content UI styling.
+
+Any style that must affect the host page should be injected explicitly
+through its own page-style injection mechanism.
+
+> This behavior is intentional and should not be reverted unless the Content UI architecture changes.
+
+---
+
 ## 2. Manual Chunking Strategy (`manualChunks`)
 
 In a multi-page browser extension, letting the bundler split code dynamically without guidance results in fragmented, duplicated code across chunks, causing critical circular dependencies and runtime crashes (Temporal Dead Zone errors). 


### PR DESCRIPTION
## Summary

Prevent Vite-extracted Content UI styles from being injected into host pages via `manifest.content_scripts[].css`.

The Content UI is rendered inside a Shadow DOM and already injects its styles into the ShadowRoot at runtime. The auto-generated content script CSS was therefore redundant and bypassed Shadow DOM isolation, allowing generic `:root` theme tokens to leak into host pages.

This change removes the generated CSS from the main content script manifest entry for both Chrome and Firefox builds.

## Impact

- Content UI continues to load styles through ShadowRoot injection.
- Page-facing features (Element Selection, Mouse Hover, Page Translation layout fixes, etc.) continue using their dedicated page-style injection paths.
- Extension pages (Popup, Sidepanel, Options, Subtitle) are unaffected.

## Documentation

- Updated the build system documentation to record the Content Script CSS ownership model and why the generated manifest CSS is intentionally removed.

Refs #147