### PR TITLE
fix(translation): recover from invalid AI JSON responses by falling back to sequential translation

### DIFF
--- a/src/features/translation/providers/BaseAIProvider.js
+++ b/src/features/translation/providers/BaseAIProvider.js
@@ -152,7 +152,26 @@ export class BaseAIProvider extends BaseProvider {
 
       // Stats recording is handled by ProviderRequestEngine. 
       // Orchestrators (like OptimizedJsonHandler or UnifiedService) handle the reporting.
-      return AIResponseParser.parseBatchResult(response, texts.length, texts, this.providerName, expectedFormat || ResponseFormat.JSON_ARRAY);
+      const parsed = AIResponseParser.parseBatchResult(response, texts.length, texts, this.providerName, expectedFormat || ResponseFormat.JSON_ARRAY);
+
+      if (parsed.contractViolation) {
+        logger.warn(`[${this.providerName}] Batch JSON response violated the structured response contract; falling back to sequential translation`);
+        return this._traditionalBatchTranslate(
+          texts,
+          sourceLang,
+          targetLang,
+          translateMode,
+          engine,
+          messageId,
+          abortController,
+          priority,
+          sessionId,
+          ResponseFormat.STRING,
+          contextMetadata || {}
+        );
+      }
+
+      return parsed.results;
     } catch (error) {
       if (sessionId) {
         import('../core/TranslationStatsManager.js').then(m => {

--- a/src/features/translation/providers/BaseAIProvider.test.js
+++ b/src/features/translation/providers/BaseAIProvider.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ResponseFormat } from '@/shared/config/translationConstants.js';
 
 // 1. Mock minimal dependencies
 vi.mock('webextension-polyfill', () => ({
@@ -35,6 +36,7 @@ vi.mock('@/shared/error-management/ErrorMatcher.js', () => ({
 
 import { BaseAIProvider } from './BaseAIProvider.js';
 import { isFatalError, isTransientError, matchErrorToType } from '@/shared/error-management/ErrorMatcher.js';
+import { AIResponseParser } from './utils/AIResponseParser.js';
 
 // Mock AIResponseParser
 vi.mock("./utils/AIResponseParser.js", () => ({
@@ -112,6 +114,44 @@ describe('BaseAIProvider', () => {
       expect(spy).toHaveBeenCalled();
       const userText = spy.mock.calls[0][1];
       expect(userText).toContain('Hello');
+    });
+  });
+
+  describe('parseBatchResult recovery verdict', () => {
+    it('should return parsed.results when contractViolation is false', async () => {
+      vi.mocked(AIResponseParser.parseBatchResult).mockReturnValue({ results: ['R1', 'R2'], contractViolation: false });
+
+      const result = await provider._translateBatch(['Hello', 'World'], 'en', 'fa', 'selection', null, null, null, 'session-1');
+
+      expect(result).toEqual(['R1', 'R2']);
+    });
+
+    it('should call _traditionalBatchTranslate exactly once when contractViolation is true', async () => {
+      vi.mocked(AIResponseParser.parseBatchResult).mockReturnValue({ results: ['R1'], contractViolation: true });
+      const fallbackSpy = vi.spyOn(provider, '_traditionalBatchTranslate').mockResolvedValue(['F1', 'F2']);
+      const texts = ['Hello', 'World'];
+
+      const result = await provider._translateBatch(texts, 'en', 'fa', 'selection', null, null, null, 'session-1');
+
+      expect(fallbackSpy).toHaveBeenCalledTimes(1);
+      expect(fallbackSpy).toHaveBeenCalledWith(
+        texts, 'en', 'fa', 'selection',
+        null, null, null, null, 'session-1',
+        ResponseFormat.STRING,
+        {}
+      );
+      expect(result).toEqual(['F1', 'F2']);
+    });
+
+    it('should NOT trigger fallback on non-fatal transport errors', async () => {
+      provider._callAI = vi.fn().mockRejectedValue(new Error('Non-Fatal-Non-Transient'));
+      const fallbackSpy = vi.spyOn(provider, '_traditionalBatchTranslate').mockResolvedValue([]);
+      const texts = ['Original 1', 'Original 2'];
+
+      const result = await provider._translateBatch(texts, 'en', 'fa', 'selection', null, null, null, 'session-1');
+
+      expect(result).toEqual(['Original 1', 'Original 2']);
+      expect(fallbackSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/translation/providers/utils/AIResponseParser.js
+++ b/src/features/translation/providers/utils/AIResponseParser.js
@@ -195,6 +195,8 @@ export const AIResponseParser = {
 
   /**
    * Parse batch translation results from JSON response.
+   * @returns {{ results: Array<string>, contractViolation: boolean }} Parsed results plus whether
+   * the response violated the structured contract (slots gap-filled or unparseable).
    */
   parseBatchResult(result, expectedCount, originalBatch, providerName = 'Unknown', expectedFormat = ResponseFormat.JSON_ARRAY) {
     try {
@@ -220,10 +222,20 @@ export const AIResponseParser = {
         }
       });
 
-      return this._fillResultsGaps(results, unmappedTexts, originalBatch, expectedCount);
+      // Contract violation: any slot that could not be mapped by id and will be gap-filled below
+      // means the AI violated the structured response contract.
+      const contractViolation = results.some(text => text === null);
+
+      return {
+        results: this._fillResultsGaps(results, unmappedTexts, originalBatch, expectedCount),
+        contractViolation
+      };
     } catch (error) {
       logger.error(`[${providerName}] Strict parse failed: ${error.message}`);
-      return originalBatch.map(item => typeof item === 'object' ? (item.t || item.text) : item);
+      return {
+        results: originalBatch.map(item => typeof item === 'object' ? (item.t || item.text) : item),
+        contractViolation: true
+      };
     }
   },
 

--- a/src/features/translation/providers/utils/AIResponseParser.test.js
+++ b/src/features/translation/providers/utils/AIResponseParser.test.js
@@ -100,4 +100,48 @@ describe('AIResponseParser', () => {
       expect(result).toBe('undefined');
     });
   });
+
+  describe('parseBatchResult - Recovery Verdict', () => {
+    it('should return contractViolation false for a complete id-mapped JSON response', () => {
+      const result = AIResponseParser.parseBatchResult(
+        '[{"id": 0, "text": "Hola"}, {"id": 1, "text": "Adiós"}]',
+        2,
+        ['Hello', 'World']
+      );
+
+      expect(result).toEqual({
+        results: ['Hola', 'Adiós'],
+        contractViolation: false
+      });
+    });
+
+    it('should return contractViolation true when slots are gap-filled', () => {
+      const result = AIResponseParser.parseBatchResult(
+        '[{"id": 0, "text": "Hola"}]',
+        2,
+        ['Hello', 'World']
+      );
+
+      expect(result).toEqual({
+        results: ['Hola', 'World'],
+        contractViolation: true
+      });
+    });
+
+    it('should return contractViolation true for malformed JSON', () => {
+      const original = ['Hello', 'World', 'Foo'];
+      const result = AIResponseParser.parseBatchResult(
+        'null',
+        3,
+        original,
+        'MockAI',
+        ResponseFormat.JSON_ARRAY
+      );
+
+      expect(result).toEqual({
+        results: original,
+        contractViolation: true
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Improve the resilience of the JSON translation pipeline by detecting structured-response contract violations and automatically falling back to sequential translation.

This change primarily improves compatibility with Local LLM providers (e.g. Ollama, LM Studio) that do not reliably return valid JSON responses for batched translation requests, while remaining a no-op for providers that already return valid structured responses.

## Changes

- Change `AIResponseParser.parseBatchResult()` to return:
  ```ts
  {
    results: string[],
    requiresRecovery: boolean
  }
  ```
- Detect when the structured JSON contract cannot be trusted (gap-filled or unparseable responses).
- Let `BaseAIProvider` decide the recovery strategy.
- Automatically retry the affected batch using sequential `STRING` translation when recovery is required.
- Preserve the existing parsing behavior and best-effort normalization.
- Keep all downstream components unchanged (`OptimizedJsonHandler`, `_mapResults`, coordinator, streaming, etc.).

## Why

Previously, malformed or incomplete JSON responses were silently normalized and propagated through the pipeline, allowing partial or corrupted translations to reach later stages.

This change makes the recovery decision explicit:

- Parser reports whether recovery is required.
- Provider owns the fallback strategy.
- Downstream pipeline continues to receive a normal translated array.

The recovery responsibility now lives in the layer that already owns translation strategy selection.

## Scope

This PR intentionally does **not** change:

- JSON parsing logic
- batching
- streaming
- retry behavior
- cancellation
- provider selection
- `reliableJsonMode`
- `OptimizedJsonHandler`
- `_mapResults`

## Validation

- Focused parser/provider tests added.
- Full translation feature test suite passes.
- ESLint clean.
- `git diff --check` clean.


Refs #164